### PR TITLE
[ORCA-133] Configure `orca` as an Airflow provider package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ platforms = any
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
+    Framework :: Apache Airflow
+    Framework :: Apache Airflow :: Provider
 
 
 [options]
@@ -99,6 +101,10 @@ dev =
 # And any other entry points, for example:
 ; console_scripts =
 ;     orca = orca.main:app
+# Based on this example:
+# https://github.com/astronomer/airflow-provider-sample/
+apache_airflow_provider =
+    provider_info = orca.airflow:get_provider_info
 
 [tool:pytest]
 # Specify command line options as you would do when invoking pytest directly.

--- a/src/orca/airflow/__init__.py
+++ b/src/orca/airflow/__init__.py
@@ -1,0 +1,3 @@
+from orca.airflow.provider_info import get_provider_info
+
+__all__ = ["get_provider_info"]

--- a/src/orca/airflow/provider_info.py
+++ b/src/orca/airflow/provider_info.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from orca import __name__ as package_name
+from orca import __version__
+from orca.services.sevenbridges.hook import SevenBridgesHook
+
+
+def generate_connection_type(hook) -> dict[str, str]:
+    """Generate an Airflow-compatible connection type.
+
+    Args:
+        hook: An Airflow hook.
+
+    Returns:
+        An Airflow-compatible connection type.
+    """
+    return {
+        "connection-type": hook.conn_type,
+        "hook-class-name": f"{hook.__module__}.{hook.__name__}",
+    }
+
+
+def get_provider_info() -> dict[str, Any]:
+    """Generate provider info to register as an Airflow provider.
+
+    Adapted from this Astronomer repository (commit SHA: 212e14ed):
+    https://github.com/astronomer/airflow-provider-sample
+
+    Returns:
+        Provider information for Airflow according to this schema:
+        https://github.com/apache/airflow/blob/main/airflow/provider_info.schema.json
+    """
+    return {
+        "package-name": package_name,
+        "versions": [__version__],
+        "name": "ORCA Airflow Provider (Sage Bionetworks)",
+        "description": "Package for connecting services and building data pipelines.",
+        "connection-types": [
+            generate_connection_type(SevenBridgesHook),
+        ],
+        # TODO: Add links to uploaded files (e.g., on Synapse) for Synapse operators
+        # "extra-links": ["sample_provider.operators.sample.SampleOperatorExtraLink"],
+    }

--- a/src/orca/services/sevenbridges/ops.py
+++ b/src/orca/services/sevenbridges/ops.py
@@ -129,8 +129,8 @@ class SevenBridgesOps:
 
         # Note that `create()` does not launch by default (run=False)
         task = self.client.tasks.create(name, self.project, app_id, inputs=inputs)
-        task.id = cast(str, task.id)
-        return task.id
+        task_id = cast(str, task.id)
+        return task_id
 
     def launch_task(self, task_id: str) -> str:
         """Launch a draft task (workflow run).
@@ -169,6 +169,6 @@ class SevenBridgesOps:
             The task status and whether it's done.
         """
         task = self.client.tasks.get(task_id)
-        task.status = cast(TaskStatus, task.status)
-        is_done = task.status in TaskStatus.terminal_states
-        return task.status, is_done
+        task_status = cast(TaskStatus, task.status)
+        is_done = task_status in TaskStatus.terminal_states
+        return task_status, is_done

--- a/tests/airflow/test_provider_info.py
+++ b/tests/airflow/test_provider_info.py
@@ -1,0 +1,24 @@
+from importlib import import_module
+
+from orca.airflow.provider_info import generate_connection_type, get_provider_info
+from orca.services.sevenbridges.hook import SevenBridgesHook
+
+
+def test_generate_connection_type():
+    result = generate_connection_type(SevenBridgesHook)
+    module_name, class_name = result["hook-class-name"].rsplit(".", maxsplit=1)
+    module = import_module(module_name)
+    assert "connection-type" in result
+    assert "hook-class-name" in result
+    assert isinstance(result["connection-type"], str)
+    assert getattr(module, class_name, None) is not None
+
+
+def test_get_provider_info():
+    result = get_provider_info()
+    assert "package-name" in result
+    assert "versions" in result
+    assert "name" in result
+    assert "description" in result
+    assert "connection-types" in result
+    assert len(result["connection-types"]) > 0


### PR DESCRIPTION
This allows the Airflow hooks to be discoverable by Airflow. One benefit of this is that it allows for the "SevenBridges" connection type in the UI, which can be useful for testing. 

<img width="1494" alt="image" src="https://user-images.githubusercontent.com/740725/217881401-b0f3fac0-1c2c-4f50-8369-e536f09160b9.png">
