### PR TITLE
[ORCA-134] Update "orca" based on Airflow testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,8 @@ repos:
   - id: interrogate
     exclude: ^(docs/conf.py|setup.py|tests)
     args: [--config=pyproject.toml]
+
+- repo: https://github.com/jendrikseipp/vulture
+  rev: 'v2.7'
+  hooks:
+    - id: vulture

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -376,6 +376,7 @@
             "hashes": [
                 "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4",
                 "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f",
+                "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885",
                 "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502",
                 "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41",
                 "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965",
@@ -386,6 +387,7 @@
                 "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388",
                 "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6",
                 "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2",
+                "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef",
                 "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac",
                 "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695",
                 "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6",
@@ -1336,11 +1338,11 @@
         },
         "tenacity": {
             "hashes": [
-                "sha256:a43bcd8910406e0884ca0db3db7bed581f389c1d05165e992a1ddabfc81df05e",
-                "sha256:b723061a78ed0f4524190eae321d3d84100227d51c5677035b6615d91895e0d6"
+                "sha256:c7bb4b86425b977726a7b49971542d4f67baf72096597d283f3ffd01f33b92df",
+                "sha256:dd1b769ca7002fda992322939feca5bee4fa11f39146b0af14e0b8d9f27ea854"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.2.0"
+            "version": "==8.2.1"
         },
         "termcolor": {
             "hashes": [
@@ -2034,6 +2036,7 @@
             "hashes": [
                 "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4",
                 "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f",
+                "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885",
                 "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502",
                 "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41",
                 "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965",
@@ -2044,6 +2047,7 @@
                 "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388",
                 "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6",
                 "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2",
+                "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef",
                 "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac",
                 "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695",
                 "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6",
@@ -3744,11 +3748,11 @@
         },
         "tenacity": {
             "hashes": [
-                "sha256:a43bcd8910406e0884ca0db3db7bed581f389c1d05165e992a1ddabfc81df05e",
-                "sha256:b723061a78ed0f4524190eae321d3d84100227d51c5677035b6615d91895e0d6"
+                "sha256:c7bb4b86425b977726a7b49971542d4f67baf72096597d283f3ffd01f33b92df",
+                "sha256:dd1b769ca7002fda992322939feca5bee4fa11f39146b0af14e0b8d9f27ea854"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.2.0"
+            "version": "==8.2.1"
         },
         "termcolor": {
             "hashes": [
@@ -3866,6 +3870,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==20.19.0"
+        },
+        "vulture": {
+            "hashes": [
+                "sha256:67fb80a014ed9fdb599dd44bb96cb54311032a104106fc2e706ef7a6dad88032",
+                "sha256:bccc51064ed76db15a6b58277cea8885936af047f53d2655fb5de575e93d0bca"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.7"
         },
         "wcwidth": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,4 @@ ignore-nested-functions = true
 
 [tool.vulture]
 paths = ["src/orca/"]
-# exclude = ["*file*.py", "dir/"]
-# ignore_decorators = ["@app.route", "@require_*"]
-# ignore_names = ["visit_*", "do_*"]
-# make_whitelist = true
 min_confidence = 80
-# sort_by_size = true
-# verbose = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,13 @@ verbose = true
 fail-under = 95
 ignore-module = true
 ignore-nested-functions = true
+
+[tool.vulture]
+paths = ["src/orca/"]
+# exclude = ["*file*.py", "dir/"]
+# ignore_decorators = ["@app.route", "@require_*"]
+# ignore_names = ["visit_*", "do_*"]
+# make_whitelist = true
+min_confidence = 80
+# sort_by_size = true
+# verbose = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,7 @@ dev =
     sphinx-autodoc-typehints~=1.21
     interrogate~=1.5
     jupyterlab~=3.6
+    vulture~=2.7
 
 [options.entry_points]
 # Add here console scripts like:
@@ -114,7 +115,7 @@ apache_airflow_provider =
 #          Comment those flags to avoid this pytest issue.
 addopts =
     --cov "orca" --cov-report "term-missing" --cov-report "xml"
-    -m "not slow and not integration"
+    -m "not slow and not integration and not acceptance"
     --verbose
 norecursedirs =
     dist
@@ -130,7 +131,7 @@ testpaths =
 markers =
     slow: mark tests as slow (deselect with '-m "not slow"')
     integration: mark tests that interact with external services
-    # acceptance: mark end-to-end acceptance tests
+    acceptance: mark end-to-end acceptance tests
 
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool

--- a/src/orca/services/sevenbridges/ops.py
+++ b/src/orca/services/sevenbridges/ops.py
@@ -47,14 +47,13 @@ class SevenBridgesOps:
     project: Optional[str] = None
 
     @classmethod
-    def from_creds(
+    def from_args(
         cls,
         api_endpoint: str,
         auth_token: str,
         project: Optional[str] = None,
-        **client_kwargs: Any,
     ) -> SevenBridgesOps:
-        """Construct SevenBridgesOps from credentials.
+        """Construct SevenBridgesOps from individual arguments.
 
         Args:
             api_endpoint: API base endpoint.
@@ -63,13 +62,11 @@ class SevenBridgesOps:
             project: An owner-prefixed SevenBridges project.
                 For example: <username>/<project-name>.
                 Defaults to None.
-            **client_kwargs: Additional keyword arguments that are passed
-                to the SevenBridges client during its construction.
 
         Returns:
             An authenticated SevenBridgesOps instance.
         """
-        factory = SevenBridgesClientFactory(api_endpoint, auth_token, client_kwargs)
+        factory = SevenBridgesClientFactory(api_endpoint, auth_token)
         client = factory.get_client()
         return SevenBridgesOps(client, project)
 

--- a/tests/acceptance/test_cavatica.py
+++ b/tests/acceptance/test_cavatica.py
@@ -1,0 +1,32 @@
+import pytest
+from sevenbridges.models.enums import TaskStatus
+
+from orca.services.sevenbridges import SevenBridgesHook
+
+
+@pytest.mark.acceptance
+def test_cavatica_launch_poc_v2(run_id):
+    def create_task():
+        hook = SevenBridgesHook()
+        task_inputs = {
+            "input_type": "FASTQ",
+            "reads1": hook.client.files.get("63e569217a0654635c558c84"),
+            "reads2": hook.client.files.get("63e5694ebfc712185ac37a27"),
+            "runThreadN": 36,
+            "wf_strand_param": "default",
+            "sample_name": "HCC1187_1M",
+            "rmats_read_length": 101,
+            "outSAMattrRGline": "ID:HCC1187_1M\tLB:NA\tPL:Illumina\tSM:HCC1187_1M",
+            "output_basename": run_id,
+        }
+        app_id = "orca-service/test-project/kfdrc-rnaseq-workflow"
+        task_id = hook.ops.create_task(run_id, app_id, task_inputs)
+        return task_id
+
+    def monitor_task(task_name):
+        hook = SevenBridgesHook()
+        return hook.ops.get_task_status(task_name)
+
+    task_id = create_task()
+    task_status, _ = monitor_task(task_id)
+    assert hasattr(TaskStatus, str(task_status))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,18 @@
+from datetime import datetime
+from getpass import getuser
+from uuid import uuid4
+
 import pytest
+
+UUID = str(uuid4())
+USER = getuser()
+UTCTIME = datetime.now().isoformat("T", "seconds").replace(":", ".")
+RUN_ID = f"{USER}--{UTCTIME}--{UUID}"  # Valid characters: [A-Za-z0-9._-]
+
+
+@pytest.fixture
+def run_id():
+    return RUN_ID
 
 
 @pytest.fixture

--- a/tests/services/sevenbridges/conftest.py
+++ b/tests/services/sevenbridges/conftest.py
@@ -2,6 +2,7 @@ from copy import copy
 from unittest.mock import MagicMock
 
 import pytest
+from airflow.exceptions import AirflowNotFoundException
 from airflow.models.connection import Connection
 from sevenbridges.api import (
     Actions,
@@ -34,6 +35,7 @@ from orca.services.sevenbridges import (
     SevenBridgesHook,
     SevenBridgesOps,
 )
+from orca.services.sevenbridges.hook import BaseHook
 
 
 @pytest.fixture
@@ -125,9 +127,9 @@ def connection(connection_uri):
 
 @pytest.fixture
 def patch_get_connection(mocker, connection):
-    connection_mock = mocker.patch.object(SevenBridgesHook, "get_connection")
-    connection_mock.return_value = connection
-    yield
+    connection_mock = mocker.patch.object(BaseHook, "get_connection")
+    connection_mock.side_effect = AirflowNotFoundException
+    yield connection_mock
 
 
 @pytest.fixture

--- a/tests/services/sevenbridges/conftest.py
+++ b/tests/services/sevenbridges/conftest.py
@@ -96,7 +96,7 @@ def ops_args(client_args):
 
 @pytest.fixture
 def mock_ops(ops_args, mock_api):
-    yield SevenBridgesOps.from_creds(**ops_args)
+    yield SevenBridgesOps.from_args(**ops_args)
 
 
 # Note that this refers to a SevenBridges task (or workflow run)

--- a/tests/services/sevenbridges/test_client_factory.py
+++ b/tests/services/sevenbridges/test_client_factory.py
@@ -37,16 +37,15 @@ class TestWithEmptyEnv:
         assert rate_limit_sleeper in handlers
 
 
-def test_that_a_nonempty_connection_can_be_mapped(connection, client_args):
-    expected = client_args
-    actual = SevenBridgesClientFactory.map_connection(connection)
-    assert actual == expected
+def test_that_a_nonempty_connection_can_be_mapped(connection, ops_args):
+    actual = SevenBridgesClientFactory.parse_connection(connection)
+    assert actual == ops_args
 
 
 def test_that_an_empty_connection_can_be_mapped():
-    expected = {"api_endpoint": None, "auth_token": None}
+    expected = {"api_endpoint": None, "auth_token": None, "project": None}
     connection = Connection(uri="sbg://")
-    result = SevenBridgesClientFactory.map_connection(connection)
+    result = SevenBridgesClientFactory.parse_connection(connection)
     assert result == expected
 
 

--- a/tests/services/sevenbridges/test_hook.py
+++ b/tests/services/sevenbridges/test_hook.py
@@ -9,8 +9,8 @@ class TestWithoutAirflow:
     def test_that_a_hook_can_be_constructed_from_a_connection(self, hook):
         assert isinstance(hook, SevenBridgesHook)
 
-    def test_that_get_conn_return_client(self, hook):
-        assert hook.get_conn() == hook.client
+    def test_that_get_conn_returns_ops_object(self, hook):
+        assert hook.get_conn() == hook.ops
 
     def test_that_the_client_object_can_be_retrieved_from_hook(self, hook):
         assert isinstance(hook.client, Api)

--- a/tests/services/sevenbridges/test_hook.py
+++ b/tests/services/sevenbridges/test_hook.py
@@ -1,6 +1,8 @@
 import pytest
+from airflow.models.connection import Connection
 from sevenbridges import Api
 
+from orca.errors import ClientArgsError
 from orca.services.sevenbridges import SevenBridgesHook, SevenBridgesOps
 
 
@@ -17,3 +19,13 @@ class TestWithoutAirflow:
 
     def test_that_the_ops_object_can_be_retrieved_from_hook(self, hook):
         assert isinstance(hook.ops, SevenBridgesOps)
+
+    def test_that_a_connection_is_returned_without_airflow(self, hook):
+        connection = hook.get_connection("foo")
+        assert isinstance(connection, Connection)
+
+    def test_for_error_without_airflow_or_env(self, hook, patch_get_connection, mocker):
+        empty_connection = Connection(uri="sbg://")
+        mocker.patch.object(hook, "connection", empty_connection)
+        with pytest.raises(ClientArgsError):
+            hook.ops

--- a/tests/services/sevenbridges/test_ops.py
+++ b/tests/services/sevenbridges/test_ops.py
@@ -7,7 +7,7 @@ from orca.services.sevenbridges import SevenBridgesOps
 @pytest.mark.usefixtures("patch_os_environ")
 class TestWithEmptyEnv:
     def test_that_constructions_from_creds_works(self, client_args, mock_api_init):
-        SevenBridgesOps.from_creds(**client_args)
+        SevenBridgesOps.from_args(**client_args)
         mock_api_init.assert_called_once()
 
     def test_for_an_error_when_using_a_project_required_method(self, mock_ops):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ extras =
     all
 commands =
     # The `-m ""` overrides the `-m "not slow"` in setup.cfg
-    pytest {posargs} -m ""
+    pytest {posargs} -m "not acceptance"
 
 
 [testenv:lint]


### PR DESCRIPTION
I was performing some testing in Airflow, and I wasn't able to get things to run from start to finish. So, I decided to write an acceptance test that emulates the DAG but without Airflow. 

I had to change a few things about how the classes interact with each other in order to allow the hook to be instantiated outside of an Airflow context, but I got it to work with minimal changes! This is great from a testing perspective! 

You'll notice that I also added `vulture` as a pre-commit hook and development dependency. I wanted to make sure that my changes didn't result in dead (_i.e.) unused) code. 