### PR TITLE
[ORCA-152] Create base class for ops

### DIFF
--- a/src/orca/services/base/ops.py
+++ b/src/orca/services/base/ops.py
@@ -5,18 +5,15 @@ from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self
 
-from orca.services.base.client_factory import BaseClientFactory
 from orca.services.base.config import BaseServiceConfig
 
 ClientClass = TypeVar("ClientClass", bound=Any)
-
-ClientFactory = TypeVar("ClientFactory", bound=BaseClientFactory)
 
 ServiceConfig = TypeVar("ServiceConfig", bound=BaseServiceConfig)
 
 
 @dataclass(kw_only=False, config=ConfigDict(arbitrary_types_allowed=True))
-class BaseOps(ABC, Generic[ServiceConfig, ClientFactory, ClientClass]):
+class BaseOps(ABC, Generic[ServiceConfig, ClientClass]):
     """Base collection of operations for a service."""
 
     # Override this type hint in subclasses to enable pydantic validation

--- a/src/orca/services/base/ops.py
+++ b/src/orca/services/base/ops.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+from typing_extensions import Self
+
+from orca.services.base.client_factory import BaseClientFactory
+from orca.services.base.config import BaseServiceConfig
+
+ClientClass = TypeVar("ClientClass", bound=Any)
+
+ClientFactory = TypeVar("ClientFactory", bound=BaseClientFactory)
+
+ServiceConfig = TypeVar("ServiceConfig", bound=BaseServiceConfig)
+
+
+@dataclass(kw_only=False, config=ConfigDict(arbitrary_types_allowed=True))
+class BaseOps(ABC, Generic[ServiceConfig, ClientFactory, ClientClass]):
+    """Base collection of operations for a service."""
+
+    # Override this type hint in subclasses to enable pydantic validation
+    client: ClientClass
+
+    @classmethod
+    @abstractmethod
+    def from_config(cls, config: ServiceConfig) -> Self:
+        """Construct an Ops instance from the service configuration.
+
+        Args:
+            config: Service configuration.
+
+        Returns:
+            An Ops class instance for this service.
+        """

--- a/tests/services/sevenbridges/test_ops.py
+++ b/tests/services/sevenbridges/test_ops.py
@@ -1,6 +1,6 @@
 import pytest
 
-from orca.errors import OptionalAttrRequiredError, UnexpectedMatchError
+from orca.errors import UnexpectedMatchError
 from orca.services.sevenbridges import SevenBridgesOps
 
 
@@ -10,10 +10,12 @@ class TestWithEmptyEnv:
         SevenBridgesOps.from_config(ops_config)
         mock_api_init.assert_called_once()
 
-    def test_for_an_error_when_using_a_project_required_method(self, mock_ops):
-        mock_ops.project = None
-        with pytest.raises(OptionalAttrRequiredError):
-            mock_ops.draft_task("foo", "bar", {})
+    def test_for_error_when_constructing_from_config_without_project(
+        self, ops_config, mock_api_init
+    ):
+        ops_config.project = None
+        with pytest.raises(ValueError):
+            SevenBridgesOps.from_config(ops_config)
 
     def test_that_the_client_is_used_to_get_a_task(self, mock_task, mock_ops):
         mock_ops.client.tasks.query.return_value = [mock_task]


### PR DESCRIPTION
Most of the functionality in the `SevenBridgesOps` class is specific to SevenBridges, so the base Ops class is small. 

I took the opportunity to remove support for an SevenBridgesOps instance without a `project`. This is an unlikely use case, so I'm dropping support. 