### PR TITLE
[ORCA-153] Create base class for hooks

### DIFF
--- a/src/orca/services/base/__init__.py
+++ b/src/orca/services/base/__init__.py
@@ -1,6 +1,6 @@
 """Submodule for base classes containing shared functionality."""
 
 from orca.services.base.client_factory import BaseClientFactory
-from orca.services.base.config import BaseServiceConfig
+from orca.services.base.config import BaseConfig
 
-__all__ = ["BaseServiceConfig", "BaseClientFactory"]
+__all__ = ["BaseConfig", "BaseClientFactory"]

--- a/src/orca/services/base/config.py
+++ b/src/orca/services/base/config.py
@@ -12,8 +12,13 @@ if TYPE_CHECKING:
 
 
 @dataclass(kw_only=False)
-class BaseServiceConfig(ABC):
-    """Simple container class for service-related configuration."""
+class BaseConfig(ABC):
+    """Simple container class for service-related configuration.
+
+    Class Variables:
+        connection_env_var: The name of the environment variable whose
+            value is an Airflow connection URI for this service.
+    """
 
     connection_env_var: ClassVar[str]
 

--- a/src/orca/services/base/hook.py
+++ b/src/orca/services/base/hook.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, Type, TypeVar
+
+from airflow.exceptions import AirflowNotFoundException
+from airflow.hooks.base import BaseHook
+
+from orca.services.base.ops import BaseOps
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
+
+ClientClass = TypeVar("ClientClass", bound=Any)
+
+OpsClass = TypeVar("OpsClass", bound=BaseOps)
+
+
+class BaseOrcaHook(BaseHook, Generic[OpsClass, ClientClass]):
+    """Wrapper around client and ops classes.
+
+    This base class is called 'BaseOrcaHook' to avoid confusion
+    with the Airflow 'BaseHook' class, which this inherits from.
+
+    This hook was inspired by the Asana Airflow provider package:
+    https://github.com/apache/airflow/blob/main/airflow/providers/asana/hooks/asana.py
+
+    Attributes:
+        conn_name_attr: Inherited Airflow attribute (e.g., "sbg_conn_id").
+        default_conn_name: Inherited Airflow attribute (e.g., "sbg_default").
+        conn_type: Inherited Airflow attribute (e.g., "sbg").
+        hook_name: Inherited Airflow attribute (e.g., "SevenBridges").
+
+    Class Variables:
+        ops_class: The Ops class for this service.
+    """
+
+    conn_name_attr: str
+    default_conn_name: str
+    conn_type: str
+    hook_name: str
+
+    ops_class: ClassVar[Type]
+
+    def __init__(self, conn_id: Optional[str] = None, *args, **kwargs):
+        """Construct hook using an Airflow connection.
+
+        Args:
+            conn_id: An Airflow connection ID.
+                Defaults to ``default_conn_name``.
+        """
+        super().__init__(*args, **kwargs)
+        conn_id = conn_id or self.default_conn_name
+        self.connection = self.get_connection(conn_id)
+
+    @classmethod
+    def get_connection(cls, conn_id: str) -> Connection:
+        """
+        Retrieve Airflow connection
+
+        Args:
+            conn_id: Airflow connection ID.
+
+        Returns:
+            An Airflow connection.
+        """
+        try:
+            connection = super().get_connection(conn_id)
+        except AirflowNotFoundException:
+            config_class = cls.ops_class.client_factory_class.config_class
+            connection = config_class.get_connection_from_env()
+        return connection
+
+    def get_conn(self) -> OpsClass:
+        """Retrieve the authenticated Ops object.
+
+        This object contains an authenticated client.
+
+        Returns:
+            An authenticated Ops object.
+        """
+        return self.ops
+
+    @cached_property
+    def client(self) -> ClientClass:
+        """Retrieve authenticated client."""
+        return self.ops.client
+
+    @cached_property
+    def ops(self) -> OpsClass:
+        """An authenticated Ops object."""
+        config_class = self.ops_class.client_factory_class.config_class
+        config = config_class.from_connection(self.connection)
+        return self.ops_class.from_config(config)

--- a/src/orca/services/base/ops.py
+++ b/src/orca/services/base/ops.py
@@ -1,27 +1,38 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, ClassVar, Generic, Type, TypeVar
 
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self
 
-from orca.services.base.config import BaseServiceConfig
+from orca.services.base.config import BaseConfig
 
 ClientClass = TypeVar("ClientClass", bound=Any)
 
-ServiceConfig = TypeVar("ServiceConfig", bound=BaseServiceConfig)
+ConfigClass = TypeVar("ConfigClass", bound=BaseConfig)
 
 
 @dataclass(kw_only=False, config=ConfigDict(arbitrary_types_allowed=True))
-class BaseOps(ABC, Generic[ServiceConfig, ClientClass]):
-    """Base collection of operations for a service."""
+class BaseOps(ABC, Generic[ConfigClass, ClientClass]):
+    """Base collection of operations for a service.
 
-    # Override this type hint in subclasses to enable pydantic validation
+    N.B. Make sure to override the type hint for the ``client`` class
+    variable in subclasses to enable pydantic validation.
+
+    Attributes:
+        client: An authenticated client object for this service.
+
+    Class Variables:
+        client_factory_class: The class for constructing clients.
+    """
+
     client: ClientClass
+
+    client_factory_class: ClassVar[Type]
 
     @classmethod
     @abstractmethod
-    def from_config(cls, config: ServiceConfig) -> Self:
+    def from_config(cls, config: ConfigClass) -> Self:
         """Construct an Ops instance from the service configuration.
 
         Args:

--- a/src/orca/services/sevenbridges/config.py
+++ b/src/orca/services/sevenbridges/config.py
@@ -1,24 +1,44 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
 
 from pydantic.dataclasses import dataclass
 
-from orca.services.base import BaseServiceConfig
+from orca.services.base import BaseConfig
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection
 
 
 @dataclass(kw_only=False)
-class SevenBridgesConfig(BaseServiceConfig):
-    """Container class for SevenBridges-related configuration."""
+class SevenBridgesConfig(BaseConfig):
+    """Container class for SevenBridges-related configuration.
+
+    Attributes:
+        api_endpoint: API endpoint for a SevenBridges platform.
+            Valid values are provided by the ``valid_api_endpoints``
+            class variable.
+        auth_token: An authentication token for the platform specified
+            by the ``api_endpoints`` value.
+        project: A SevenBridges project name (prefixed by username).
+
+    Class Variables:
+        connection_env_var: The name of the environment variable whose
+            value is an Airflow connection URI for this service.
+        api_endpoints: The set of currently supported API endpoints.
+    """
 
     api_endpoint: Optional[str] = None
     auth_token: Optional[str] = None
     project: Optional[str] = None
 
     connection_env_var = "SEVENBRIDGES_CONNECTION_URI"
+
+    valid_api_endpoints: ClassVar[set[str]] = {
+        "https://api.sbgenomics.com/v2",
+        "https://cgc-api.sbgenomics.com/v2",
+        "https://cavatica-api.sbgenomics.com/v2",
+    }
 
     @classmethod
     def from_connection(cls, connection: Connection) -> SevenBridgesConfig:

--- a/src/orca/services/sevenbridges/hook.py
+++ b/src/orca/services/sevenbridges/hook.py
@@ -1,24 +1,18 @@
-from __future__ import annotations
-
-from functools import cached_property
-from typing import TYPE_CHECKING
-
-from airflow.exceptions import AirflowNotFoundException
-from airflow.hooks.base import BaseHook
-from sevenbridges import Api
-
-from orca.services.sevenbridges.config import SevenBridgesConfig
+from orca.services.base.hook import BaseOrcaHook
 from orca.services.sevenbridges.ops import SevenBridgesOps
 
-if TYPE_CHECKING:
-    from airflow.models.connection import Connection
 
-
-class SevenBridgesHook(BaseHook):
+class SevenBridgesHook(BaseOrcaHook):
     """Wrapper around SevenBridges client and ops classes.
 
-    This hook was inspired by the Asana Airflow provider package:
-    https://github.com/apache/airflow/blob/main/airflow/providers/asana/hooks/asana.py
+    Attributes:
+        conn_name_attr: Inherited Airflow attribute (e.g., "sbg_conn_id").
+        default_conn_name: Inherited Airflow attribute (e.g., "sbg_default").
+        conn_type: Inherited Airflow attribute (e.g., "sbg").
+        hook_name: Inherited Airflow attribute (e.g., "SevenBridges").
+
+    Class Variables:
+        ops_class: The Ops class for this service.
     """
 
     conn_name_attr = "sbg_conn_id"
@@ -26,52 +20,4 @@ class SevenBridgesHook(BaseHook):
     conn_type = "sbg"
     hook_name = "SevenBridges"
 
-    def __init__(self, conn_id: str = default_conn_name, *args, **kwargs):
-        """Construct SevenBridgesHook using an Airflow connection.
-
-        Args:
-            conn_id: An Airflow connection ID.
-                Defaults to ``default_conn_name``.
-        """
-        super().__init__(*args, **kwargs)
-        self.connection = self.get_connection(conn_id)
-        extras = self.connection.extra_dejson
-        self.project = extras.get("project")
-
-    @classmethod
-    def get_connection(cls, conn_id: str) -> Connection:
-        """
-        Retrieve Airflow connection
-
-        Args:
-            conn_id: Airflow connection ID.
-
-        Returns:
-            An Airflow connection.
-        """
-        try:
-            connection = super().get_connection(conn_id)
-        except AirflowNotFoundException:
-            connection = SevenBridgesConfig.get_connection_from_env()
-        return connection
-
-    def get_conn(self) -> SevenBridgesOps:
-        """Retrieve the authenticated SevenBridgesOps object.
-
-        This object contains an authenticated SevenBridges client.
-
-        Returns:
-            An authenticated SevenBridgesOps instance.
-        """
-        return self.ops
-
-    @cached_property
-    def client(self) -> Api:
-        """Retrieve authenticated SevenBridges client."""
-        return self.ops.client
-
-    @cached_property
-    def ops(self) -> SevenBridgesOps:
-        """An authenticated SevenBridgesOps instance."""
-        config = SevenBridgesConfig.from_connection(self.connection)
-        return SevenBridgesOps.from_config(config)
+    ops_class = SevenBridgesOps

--- a/src/orca/services/sevenbridges/ops.py
+++ b/src/orca/services/sevenbridges/ops.py
@@ -20,11 +20,16 @@ class SevenBridgesOps(BaseOps):
 
     Attributes:
         client: An authenticated SevenBridges client.
-        project: A SevenBridges project (prefixed by username).
+        project: A SevenBridges project name (prefixed by username).
+
+    Class Variables:
+        client_factory_class: The class for constructing clients.
     """
 
     client: Api
     project: str
+
+    client_factory_class = SevenBridgesClientFactory
 
     @classmethod
     def from_config(cls, config: SevenBridgesConfig) -> Self:
@@ -36,7 +41,7 @@ class SevenBridgesOps(BaseOps):
         Returns:
             An Ops class instance for this service.
         """
-        factory = SevenBridgesClientFactory.from_config(config)
+        factory = cls.client_factory_class.from_config(config)
         client = factory.get_client()
         if config.project is None:
             message = "The 'project' field must be set in the config ({config})."

--- a/tests/services/sevenbridges/conftest.py
+++ b/tests/services/sevenbridges/conftest.py
@@ -30,13 +30,13 @@ from sevenbridges.api import (
     Volume,
 )
 
+from orca.services.base.hook import BaseHook
 from orca.services.sevenbridges import (
     SevenBridgesClientFactory,
     SevenBridgesHook,
     SevenBridgesOps,
 )
 from orca.services.sevenbridges.client_factory import SevenBridgesConfig
-from orca.services.sevenbridges.hook import BaseHook
 
 
 @pytest.fixture


### PR DESCRIPTION
The hook class was an excellent candidate for creating a base class. Most of its functionality is service-agnostic beyond its reliance on the base classes for Ops, ClientFactory, and Config. 

I took the opportunity to polish the class docstrings and consistently document the class variables and attributes. 