### PR TITLE
[ORCA-154] Migrate config-related code to `BaseConfig` and improve docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ check_untyped_defs = true
 
 [tool.interrogate]
 verbose = true
-fail-under = 95
+fail-under = 100
 ignore-module = true
 ignore-nested-functions = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ install_requires =
     apache-airflow~=2.4
     pydantic~=1.10
     sqlalchemy<2.0  # To address SQLAlchemy warning (https://sqlalche.me/e/b8d9)
+    typing-extensions~=4.5
 
 [options.packages.find]
 where = src
@@ -65,9 +66,10 @@ exclude =
 # `pip install orca[PDF]` like:
 # PDF = ReportLab; RXP
 
-# Additional dependencies for compute tests
+# Additional dependencies for specific services
 all =
     sevenbridges-python~=2.9
+    requests~=2.28
 
 # Dependencies for testing (used by tox and Pipenv)
 testing =

--- a/src/orca/errors.py
+++ b/src/orca/errors.py
@@ -9,12 +9,8 @@ class ClientRequestError(OrcaError):
     """Client request failed."""
 
 
-class ConfigError(OrcaError):
-    """Client attributes are missing or invalid."""
-
-
-class OptionalAttrRequiredError(OrcaError):
-    """Optional attribute is required in this context."""
+class ConfigError(OrcaError, AttributeError):
+    """Missing or invalid configuration attribute(s)."""
 
 
 class UnexpectedMatchError(OrcaError):

--- a/src/orca/errors.py
+++ b/src/orca/errors.py
@@ -9,7 +9,7 @@ class ClientRequestError(OrcaError):
     """Client request failed."""
 
 
-class ClientAttrError(OrcaError):
+class ConfigError(OrcaError):
     """Client attributes are missing or invalid."""
 
 

--- a/src/orca/services/base/__init__.py
+++ b/src/orca/services/base/__init__.py
@@ -2,5 +2,7 @@
 
 from orca.services.base.client_factory import BaseClientFactory
 from orca.services.base.config import BaseConfig
+from orca.services.base.hook import BaseOrcaHook
+from orca.services.base.ops import BaseOps
 
-__all__ = ["BaseConfig", "BaseClientFactory"]
+__all__ = ["BaseConfig", "BaseClientFactory", "BaseOps", "BaseOrcaHook"]

--- a/src/orca/services/base/client_factory.py
+++ b/src/orca/services/base/client_factory.py
@@ -62,7 +62,7 @@ class BaseClientFactory(ABC, Generic[ClientClass, ConfigClass]):
         is made but indicates a problem.
 
         Args:
-            client: An authenticated client for this service.
+            client: An authenticated client object.
         """
 
     @classmethod
@@ -70,7 +70,7 @@ class BaseClientFactory(ABC, Generic[ClientClass, ConfigClass]):
         """Test the client with an authenticated request.
 
         Args:
-            client: An authenticated client for this service.
+            client: An authenticated client object.
 
         Raises:
             ClientRequestError: If an error occured while making a request.

--- a/src/orca/services/base/client_factory.py
+++ b/src/orca/services/base/client_factory.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Any, ClassVar, Generic, Type, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic.dataclasses import dataclass
-from typing_extensions import Self
 
+from orca.errors import ClientRequestError
 from orca.services.base.config import BaseConfig
 
 ClientClass = TypeVar("ClientClass", bound=Any)
@@ -18,84 +18,60 @@ ConfigClass = TypeVar("ConfigClass", bound=BaseConfig)
 class BaseClientFactory(ABC, Generic[ClientClass, ConfigClass]):
     """Base factory for constructing clients.
 
+    Attributes:
+        config: Configuration relevant to this service.
+
     Class Variables:
         connection_env_var: The name of the environment variable whose
             value is an Airflow connection URI for this service.
     """
 
-    config_class: ClassVar[Type]
-    client_class: ClassVar[Type]
-
-    # Using `__post_init_post_parse__()` to perform steps after validation
-    def __post_init_post_parse__(self) -> None:
-        """Resolve any attributes using the available methods."""
-        self.resolve()
+    config: ConfigClass
 
     @abstractmethod
-    def update_with_config(self, config: ConfigClass):
-        """Update instance attributes based on client configuration.
+    def create_client(self) -> ClientClass:
+        """Create an authenticated client.
 
-        Args:
-            config: Arguments relevant to this service.
-        """
-
-    @abstractmethod
-    def validate(self) -> None:
-        """Validate the currently available attributes.
+        Typically, this involves pulling values from the configuration,
+        ensuring that non-optional arguments are not set to None, and
+        using them to instantiate a client class.
 
         Raises:
-            ClientAttrError: If one of the attributes is invalid.
-        """
-
-    @abstractmethod
-    def prepare_client_kwargs(self) -> dict[str, Any]:
-        """Prepare client keyword arguments.
+            ConfigError: If the configuration is invalid.
 
         Returns:
-            Dictionary of keyword arguments.
+            An authenticated client object.
         """
 
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def test_client(client: ClientClass) -> None:
+    def test_client_request(cls, client: ClientClass) -> None:
+        """Make a test request with an authenticated request.
+
+        This method does not need to perform any error handling.
+        That is taken care of by the ``test_client()`` method.
+        That said, this method can raise an error if a response
+        is made but indicates a problem.
+
+        Args:
+            An authenticated instance of the client for this service.
+        """
+
+    @classmethod
+    def test_client(cls, client: ClientClass) -> None:
         """Test the client with an authenticated request.
+
+        Args:
+            An authenticated instance of the client for this service.
 
         Raises:
             ClientRequestError: If an error occured while making a request.
         """
-
-    @classmethod
-    def from_config(cls, config: ConfigClass) -> Self:
-        """Construct client factory from configuration.
-
-        Args:
-            config: Arguments relevant to this service.
-
-        Returns:
-            An instantiated client factory.
-        """
-        factory = cls()
-        factory.update_with_config(config)
-        return factory
-
-    def resolve(self) -> None:
-        """Resolve credentials based on priority.
-
-        This method will update the attribute values (if applicable).
-        """
-        config = self.config_class.from_env()
-        self.update_with_config(config)
-
-    def create_client(self) -> ClientClass:
-        """Create authenticated client using the available attributes.
-
-        Returns:
-            An authenticated client for this service.
-        """
-        self.validate()
-        kwargs = self.prepare_client_kwargs()
-        client = self.client_class(**kwargs)
-        return client
+        try:
+            cls.test_client_request(client)
+        except Exception as error:
+            message = "Authenticated test request failed using the client."
+            raise ClientRequestError(message) from error
 
     @cached_property
     def _client(self) -> ClientClass:

--- a/src/orca/services/base/config.py
+++ b/src/orca/services/base/config.py
@@ -21,7 +21,7 @@ class BaseConfig(ABC):
         2) Decorate this class with ``@dataclass`` as this one does.
         3) Provide values to all class variables (defined below).
         4) Provide implementations for all abstract methods.
-        5) Verify that any assumptions defined below are met.
+        5) Verify that the assumptions defined below are met.
         6) (Optional) Implement custom Pydantic validators
 
     Assumptions:
@@ -83,7 +83,7 @@ class BaseConfig(ABC):
         """Fill in missing attributes with another configuration.
 
         Args:
-            other: Another configuration object.
+            kwargs: Keyword arguments for this configuration.
         """
         for field in fields(self):
             name = field.name

--- a/src/orca/services/base/config.py
+++ b/src/orca/services/base/config.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar
+from dataclasses import fields
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self
@@ -15,6 +16,19 @@ if TYPE_CHECKING:
 class BaseConfig(ABC):
     """Simple container class for service-related configuration.
 
+    Usage Instructions:
+        1) Create a class that subclasses this base class.
+        2) Decorate this class with ``@dataclass`` as this one does.
+        3) Provide values to all class variables (defined below).
+        4) Provide implementations for all abstract methods.
+        5) Verify that any assumptions defined below are met.
+        6) (Optional) Implement custom Pydantic validators
+
+    Assumptions:
+        This base class assumes that all attributes are optional. It is
+            the responsibility of the calling context to ensure that a
+            configuration instance has the values it needs.
+
     Class Variables:
         connection_env_var: The name of the environment variable whose
             value is an Airflow connection URI for this service.
@@ -24,6 +38,17 @@ class BaseConfig(ABC):
 
     @classmethod
     @abstractmethod
+    def parse_connection(cls, connection: Connection) -> dict[str, Any]:
+        """Parse Airflow connection as arguments for this configuration.
+
+        Args:
+            connection: An Airflow connection object.
+
+        Returns:
+            Keyword arguments for this configuration.
+        """
+
+    @classmethod
     def from_connection(cls, connection: Connection) -> Self:
         """Parse Airflow connection as a service configuration.
 
@@ -33,24 +58,38 @@ class BaseConfig(ABC):
         Returns:
             Configuration relevant to this service.
         """
+        kwargs = cls.parse_connection(connection)
+        return cls(**kwargs)
 
-    @classmethod
-    def from_env(cls) -> Self:
-        """Parse environment as a service configuration.
+    def __post_init_post_parse__(self) -> None:
+        """Resolve any attributes using the available methods.
+
+        This method is run after pydantic validation:
+        https://docs.pydantic.dev/usage/dataclasses/#initialize-hooks
+        """
+        self.resolve()
+
+    def resolve(self) -> None:
+        """Resolve credentials based on priority.
+
+        This method will update the attribute values (if applicable).
+        """
+        if self.is_env_available():
+            env_connection = self.get_connection_from_env()
+            env_kwargs = self.parse_connection(env_connection)
+            self.fill_in(env_kwargs)
+
+    def fill_in(self, kwargs: dict[str, Any]) -> None:
+        """Fill in missing attributes with another configuration.
 
         Args:
-            connection: An Airflow connection object.
-
-        Returns:
-            Configuration relevant to this service.
+            other: Another configuration object.
         """
-        # Short-circuit method if absent because Connection is slow-ish
-        if cls.is_env_available():
-            connection = cls.get_connection_from_env()
-            config = cls.from_connection(connection)
-        else:
-            config = cls()
-        return config
+        for field in fields(self):
+            name = field.name
+            if getattr(self, name, None) is None:
+                other_value = kwargs.get(name, None)
+                setattr(self, name, other_value)
 
     @classmethod
     def get_connection_from_env(cls) -> Connection:

--- a/src/orca/services/base/hook.py
+++ b/src/orca/services/base/hook.py
@@ -25,20 +25,23 @@ class BaseOrcaHook(BaseHook, Generic[OpsClass, ClientClass]):
     This hook was inspired by the Asana Airflow provider package:
     https://github.com/apache/airflow/blob/main/airflow/providers/asana/hooks/asana.py
 
-    Attributes:
+    Usage Instructions:
+        1) Create a class that subclasses this base class.
+        2) Provide values to all class variables (defined below).
+
+    Class Variables:
         conn_name_attr: Inherited Airflow attribute (e.g., "sbg_conn_id").
         default_conn_name: Inherited Airflow attribute (e.g., "sbg_default").
         conn_type: Inherited Airflow attribute (e.g., "sbg").
         hook_name: Inherited Airflow attribute (e.g., "SevenBridges").
-
-    Class Variables:
         ops_class: The Ops class for this service.
+        config_class: The configuration class for this service.
     """
 
-    conn_name_attr: str
-    default_conn_name: str
-    conn_type: str
-    hook_name: str
+    conn_name_attr: ClassVar[str]
+    default_conn_name: ClassVar[str]
+    conn_type: ClassVar[str]
+    hook_name: ClassVar[str]
 
     ops_class: ClassVar[Type]
     config_class: ClassVar[Type]

--- a/src/orca/services/base/hook.py
+++ b/src/orca/services/base/hook.py
@@ -41,6 +41,7 @@ class BaseOrcaHook(BaseHook, Generic[OpsClass, ClientClass]):
     hook_name: str
 
     ops_class: ClassVar[Type]
+    config_class: ClassVar[Type]
 
     def __init__(self, conn_id: Optional[str] = None, *args, **kwargs):
         """Construct hook using an Airflow connection.
@@ -67,8 +68,7 @@ class BaseOrcaHook(BaseHook, Generic[OpsClass, ClientClass]):
         try:
             connection = super().get_connection(conn_id)
         except AirflowNotFoundException:
-            config_class = cls.ops_class.client_factory_class.config_class
-            connection = config_class.get_connection_from_env()
+            connection = cls.config_class.get_connection_from_env()
         return connection
 
     def get_conn(self) -> OpsClass:
@@ -89,6 +89,5 @@ class BaseOrcaHook(BaseHook, Generic[OpsClass, ClientClass]):
     @cached_property
     def ops(self) -> OpsClass:
         """An authenticated Ops object."""
-        config_class = self.ops_class.client_factory_class.config_class
-        config = config_class.from_connection(self.connection)
-        return self.ops_class.from_config(config)
+        config = self.config_class.from_connection(self.connection)
+        return self.ops_class(config)

--- a/src/orca/services/base/ops.py
+++ b/src/orca/services/base/ops.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from functools import cached_property
 from typing import Any, ClassVar, Generic, Type, TypeVar
 
@@ -12,14 +11,18 @@ ConfigClass = TypeVar("ConfigClass", bound=BaseConfig)
 
 
 @dataclass(kw_only=False)
-class BaseOps(ABC, Generic[ConfigClass, ClientClass]):
+class BaseOps(Generic[ConfigClass, ClientClass]):
     """Base collection of operations for a service.
 
-    N.B. Make sure to override the type hint for the ``client`` class
-    variable in subclasses to enable pydantic validation.
+    Usage Instructions:
+        1) Create a class that subclasses this base class.
+        2) Decorate this class with ``@dataclass`` as this one does.
+        3) Provide values to all class variables (defined below).
+        4) Provide implementations for all abstract methods.
+        5) Update the type hints for attributes and class variables.
 
     Attributes:
-        client: An authenticated client object for this service.
+        config: A configuration object for this service.
 
     Class Variables:
         client_factory_class: The class for constructing clients.

--- a/src/orca/services/sevenbridges/client_factory.py
+++ b/src/orca/services/sevenbridges/client_factory.py
@@ -73,6 +73,6 @@ class SevenBridgesClientFactory(BaseClientFactory):
         is made but indicates a problem.
 
         Args:
-            client: An authenticated client for this service.
+            client: An authenticated client object.
         """
         client.users.me()

--- a/src/orca/services/sevenbridges/client_factory.py
+++ b/src/orca/services/sevenbridges/client_factory.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import field
-from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic.dataclasses import dataclass
 from sevenbridges import Api
 from sevenbridges.http.error_handlers import maintenance_sleeper, rate_limit_sleeper
 
-from orca.errors import ClientAttrError, ClientRequestError
+from orca.errors import ConfigError
 from orca.services.base import BaseClientFactory
 from orca.services.sevenbridges.config import SevenBridgesConfig
 
@@ -16,15 +14,6 @@ from orca.services.sevenbridges.config import SevenBridgesConfig
 @dataclass(kw_only=False)
 class SevenBridgesClientFactory(BaseClientFactory):
     """Factory for constructing SevenBridges clients.
-
-    SevenBridges credentials can be provided in a few ways. The
-    following methods are listed in order of decreasing prededence.
-
-        Init parameters: You provide the API URL and authentication
-            auth_token directly when you initialize this class.
-        Environment variable: You provide an Airflow connection URI via
-            an environment variable. The environment variable name is
-            defined by `SevenBridgesConfig.connection_env_var`.
 
     By default, the client will be configured with two recommended
     error handlers, which are provided by the SevenBridges package:
@@ -35,85 +24,53 @@ class SevenBridgesClientFactory(BaseClientFactory):
             API is in maintenance mode.
 
     Attributes:
-        api_endpoint: API endpoint for a SevenBridges platform.
-            Valid values are provided by the ``valid_api_endpoints``
-            class variable.
-        auth_token: An authentication token for the platform specified
-            by the ``api_endpoints`` value.
-        client_kwargs: Additional keyword arguments that are passed to
-            the SevenBridges client during its construction.
+        config: A SevenBridges configuration object, which contains
+            values relevant to client creation.
     """
 
-    api_endpoint: Optional[str] = None
-    auth_token: Optional[str] = None
-    client_kwargs: dict[str, Any] = field(default_factory=dict)
+    config: SevenBridgesConfig
 
-    config_class = SevenBridgesConfig
     client_class = Api
 
-    def update_with_config(self, config: SevenBridgesConfig):
-        """Update instance attributes based on client configuration.
+    def create_client(self) -> Api:
+        """Create an authenticated client.
 
-        Args:
-            config: Arguments relevant to this service.
-        """
-        self.api_endpoint = self.api_endpoint or config.api_endpoint
-        self.auth_token = self.auth_token or config.auth_token
-
-    def validate(self) -> None:
-        """Validate the currently available attributes.
+        Typically, this involves pulling values from the configuration,
+        ensuring that non-optional arguments are not set to None, and
+        using them to instantiate a client class.
 
         Raises:
-            ClientAttrError: If one of the attributes is invalid.
-        """
-        # Prepare a common error message for the entire function
-        common_message = (
-            "Missing or invalid credentials: "
-            f"api_endpoint = '{self.api_endpoint}' and "
-            f"auth_token = '{self.auth_token}'. "
-        )
-
-        if self.api_endpoint is None or self.auth_token is None:
-            addendum = (
-                "One of the resolved values is unset (None). Review "
-                "the class docstring to learn about methods for "
-                "providing SevenBridges credentials."
-            )
-            raise ClientAttrError(common_message + addendum)
-
-        valid_api_endpoints = self.config_class.valid_api_endpoints
-        if self.api_endpoint not in valid_api_endpoints:
-            addendum = f"API ({self.api_endpoint}) is not among {valid_api_endpoints}."
-            raise ClientAttrError(common_message + addendum)
-
-    def prepare_client_kwargs(self) -> dict[str, Any]:
-        """Prepare client keyword arguments.
+            ConfigError: If the configuration is invalid.
 
         Returns:
-            Dictionary of keyword arguments.
+            An authenticated client object.
         """
-        if TYPE_CHECKING:
-            assert self.api_endpoint
+        kwargs = deepcopy(self.config.client_kwargs)
+        api_endpoint = self.config.api_endpoint
+        auth_token = self.config.auth_token
 
-        kwargs = deepcopy(self.client_kwargs)
+        if api_endpoint is None or auth_token is None:
+            message = f"Config ({self.config}) is missing api_endpoint or auth_token."
+            raise ConfigError(message)
 
         default_handlers = [rate_limit_sleeper, maintenance_sleeper]
         kwargs.setdefault("error_handlers", default_handlers)
 
-        kwargs["url"] = self.api_endpoint.rstrip("/")
-        kwargs["token"] = self.auth_token
+        kwargs["url"] = api_endpoint.rstrip("/")
+        kwargs["token"] = auth_token
 
-        return kwargs
+        return Api(**kwargs)
 
     @staticmethod
-    def test_client(client: Api) -> None:
-        """Test the client with an authenticated request.
+    def test_client_request(client: Api) -> None:
+        """Make a test request with an authenticated request.
 
-        Raises:
-            ClientRequestError: If an error occured while making a request.
+        This method does not need to perform any error handling.
+        That is taken care of by the ``test_client()`` method.
+        That said, this method can raise an error if a response
+        is made but indicates a problem.
+
+        Args:
+            An authenticated instance of the client for this service.
         """
-        try:
-            client.users.me()
-        except Exception as error:
-            message = "Failed to retrieve active user information using the client."
-            raise ClientRequestError(message) from error
+        client.users.me()

--- a/src/orca/services/sevenbridges/client_factory.py
+++ b/src/orca/services/sevenbridges/client_factory.py
@@ -24,8 +24,10 @@ class SevenBridgesClientFactory(BaseClientFactory):
             API is in maintenance mode.
 
     Attributes:
-        config: A SevenBridges configuration object, which contains
-            values relevant to client creation.
+        config: Configuration object for this service.
+
+    Class Variables:
+        client_class: The client class for this service.
     """
 
     config: SevenBridgesConfig
@@ -71,6 +73,6 @@ class SevenBridgesClientFactory(BaseClientFactory):
         is made but indicates a problem.
 
         Args:
-            An authenticated instance of the client for this service.
+            client: An authenticated client for this service.
         """
         client.users.me()

--- a/src/orca/services/sevenbridges/config.py
+++ b/src/orca/services/sevenbridges/config.py
@@ -30,11 +30,12 @@ class SevenBridgesConfig(BaseConfig):
         auth_token: An authentication token for the platform specified
             by the ``api_endpoints`` value.
         project: A SevenBridges project name (prefixed by username).
+        client_kwargs: Keyword arguments for the SevenBridges Api class
+            in the form of a dictionary.
 
     Class Variables:
         connection_env_var: The name of the environment variable whose
             value is an Airflow connection URI for this service.
-        api_endpoints: The set of currently supported API endpoints.
     """
 
     api_endpoint: Optional[str] = None
@@ -46,6 +47,17 @@ class SevenBridgesConfig(BaseConfig):
 
     @validator("api_endpoint")
     def validate_api_endpoint(cls, value: str):
+        """Validate the value of `api_endpoint`.
+
+        Args:
+            value: The SevenBridges API endpoint.
+
+        Raises:
+            ValueError: If the value isn't among the valid options.
+
+        Returns:
+            The input value, unchanged.
+        """
         if value is not None and value not in API_ENDPOINTS:
             message = f"API endpoint ({value}) is not among {API_ENDPOINTS}."
             raise ValueError(message)
@@ -53,13 +65,13 @@ class SevenBridgesConfig(BaseConfig):
 
     @classmethod
     def parse_connection(cls, connection: Connection) -> dict[str, Any]:
-        """Parse Airflow connection as a service configuration.
+        """Parse Airflow connection as arguments for this configuration.
 
         Args:
             connection: An Airflow connection object.
 
         Returns:
-            Configuration relevant to this service.
+            Keyword arguments for this configuration.
         """
         api_endpoint = None
         if connection.host:

--- a/src/orca/services/sevenbridges/hook.py
+++ b/src/orca/services/sevenbridges/hook.py
@@ -1,4 +1,5 @@
 from orca.services.base.hook import BaseOrcaHook
+from orca.services.sevenbridges.config import SevenBridgesConfig
 from orca.services.sevenbridges.ops import SevenBridgesOps
 
 
@@ -21,3 +22,4 @@ class SevenBridgesHook(BaseOrcaHook):
     hook_name = "SevenBridges"
 
     ops_class = SevenBridgesOps
+    config_class = SevenBridgesConfig

--- a/src/orca/services/sevenbridges/hook.py
+++ b/src/orca/services/sevenbridges/hook.py
@@ -6,14 +6,13 @@ from orca.services.sevenbridges.ops import SevenBridgesOps
 class SevenBridgesHook(BaseOrcaHook):
     """Wrapper around SevenBridges client and ops classes.
 
-    Attributes:
+    Class Variables:
         conn_name_attr: Inherited Airflow attribute (e.g., "sbg_conn_id").
         default_conn_name: Inherited Airflow attribute (e.g., "sbg_default").
         conn_type: Inherited Airflow attribute (e.g., "sbg").
         hook_name: Inherited Airflow attribute (e.g., "SevenBridges").
-
-    Class Variables:
         ops_class: The Ops class for this service.
+        config_class: The configuration class for this service.
     """
 
     conn_name_attr = "sbg_conn_id"

--- a/src/orca/services/sevenbridges/ops.py
+++ b/src/orca/services/sevenbridges/ops.py
@@ -1,52 +1,40 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import Any, Optional, cast
 
-from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
-from sevenbridges import Api
 from sevenbridges.models.enums import TaskStatus
-from typing_extensions import Self
 
-from orca.errors import UnexpectedMatchError
+from orca.errors import ConfigError, UnexpectedMatchError
 from orca.services.base.ops import BaseOps
 from orca.services.sevenbridges.client_factory import SevenBridgesClientFactory
 from orca.services.sevenbridges.config import SevenBridgesConfig
 
 
-@dataclass(kw_only=False, config=ConfigDict(arbitrary_types_allowed=True))
+@dataclass(kw_only=False)
 class SevenBridgesOps(BaseOps):
     """Common operations for SevenBridges platforms.
 
     Attributes:
-        client: An authenticated SevenBridges client.
-        project: A SevenBridges project name (prefixed by username).
+        config: A SevenBridges configuration object, which contains
+            values relevant to client creation.
 
     Class Variables:
         client_factory_class: The class for constructing clients.
     """
 
-    client: Api
-    project: str
+    config: SevenBridgesConfig
 
     client_factory_class = SevenBridgesClientFactory
 
-    @classmethod
-    def from_config(cls, config: SevenBridgesConfig) -> Self:
-        """Construct an Ops instance from the service configuration.
-
-        Args:
-            config: SevenBridges configuration.
-
-        Returns:
-            An Ops class instance for this service.
-        """
-        factory = cls.client_factory_class.from_config(config)
-        client = factory.get_client()
-        if config.project is None:
-            message = "The 'project' field must be set in the config ({config})."
-            raise ValueError(message)
-        return cls(client, config.project)
+    @cached_property
+    def project(self) -> str:
+        """The currently active SevenBridges project."""
+        if self.config.project is None:
+            message = f"Config ({self.config}) does not specify a project."
+            raise ConfigError(message)
+        return self.config.project
 
     def get_task(self, name: str, app_id: str) -> Optional[str]:
         """Retrieve a task ID based on some filters.

--- a/src/orca/services/sevenbridges/ops.py
+++ b/src/orca/services/sevenbridges/ops.py
@@ -17,8 +17,7 @@ class SevenBridgesOps(BaseOps):
     """Common operations for SevenBridges platforms.
 
     Attributes:
-        config: A SevenBridges configuration object, which contains
-            values relevant to client creation.
+        config: A configuration object for this service.
 
     Class Variables:
         client_factory_class: The class for constructing clients.

--- a/tests/services/sevenbridges/test_client_factory.py
+++ b/tests/services/sevenbridges/test_client_factory.py
@@ -1,9 +1,11 @@
 import pytest
 from airflow.models.connection import Connection
+from pydantic.error_wrappers import ValidationError
 from sevenbridges import Api
+from sevenbridges.errors import SbgError
 from sevenbridges.http.error_handlers import maintenance_sleeper, rate_limit_sleeper
 
-from orca.errors import ClientAttrError, ClientRequestError
+from orca.errors import ClientRequestError, ConfigError
 from orca.services.sevenbridges.client_factory import (
     SevenBridgesClientFactory,
     SevenBridgesConfig,
@@ -13,33 +15,31 @@ from orca.services.sevenbridges.client_factory import (
 @pytest.mark.usefixtures("patch_os_environ")
 class TestWithEmptyEnv:
     def test_for_an_error_when_using_unrecognized_api_endpoints(self):
-        with pytest.raises(ClientAttrError):
-            SevenBridgesClientFactory("foo", "bar").get_client()
-        with pytest.raises(ClientAttrError):
-            SevenBridgesClientFactory(
-                "https://foo.sbgenomics.com/v2", "bar"
-            ).get_client()
-        with pytest.raises(ClientAttrError):
-            SevenBridgesClientFactory(
-                "https://api.sbgenomics.com/v1", "bar"
-            ).get_client()
+        with pytest.raises(ValidationError):
+            config = SevenBridgesConfig("foo", "bar")
+            SevenBridgesClientFactory(config)
+        with pytest.raises(ValidationError):
+            config = SevenBridgesConfig("https://foo.sbgenomics.com/v2", "bar")
+            SevenBridgesClientFactory(config)
+        with pytest.raises(ValidationError):
+            config = SevenBridgesConfig("https://api.sbgenomics.com/v1", "bar")
+            SevenBridgesClientFactory(config)
 
     def test_for_an_error_when_using_invalid_authentication_token(self):
-        with pytest.raises(ClientAttrError):
-            SevenBridgesClientFactory("https://api.sbgenomics.com/v2", "").get_client()
-        with pytest.raises(ClientAttrError):
-            SevenBridgesClientFactory("https://api.sbgenomics.com/v2").get_client()
+        with pytest.raises(SbgError):
+            config = SevenBridgesConfig("https://api.sbgenomics.com/v2", "")
+            SevenBridgesClientFactory(config).get_client()
 
     def test_for_an_error_when_missing_credentials(self):
-        with pytest.raises(ClientAttrError):
-            SevenBridgesClientFactory(
-                "https://api.sbgenomics.com/v2", None
-            ).get_client()
-        with pytest.raises(ClientAttrError):
-            SevenBridgesClientFactory(None, "bar").get_client()
+        with pytest.raises(ConfigError):
+            config = SevenBridgesConfig("https://api.sbgenomics.com/v2", None)
+            SevenBridgesClientFactory(config).get_client()
+        with pytest.raises(ConfigError):
+            config = SevenBridgesConfig(None, "bar")
+            SevenBridgesClientFactory(config).get_client()
 
-    def test_that_the_default_error_handlers_are_used(self, client_args, mock_api_init):
-        factory = SevenBridgesClientFactory(**client_args)
+    def test_that_the_default_error_handlers_are_used(self, config, mock_api_init):
+        factory = SevenBridgesClientFactory(config)
         factory.get_client()
         _, kwargs = mock_api_init.call_args
         assert "error_handlers" in kwargs
@@ -48,9 +48,9 @@ class TestWithEmptyEnv:
         assert rate_limit_sleeper in handlers
 
 
-def test_that_a_nonempty_connection_can_be_mapped(connection, ops_args):
+def test_that_a_nonempty_connection_can_be_mapped(connection, config):
     actual = SevenBridgesConfig.from_connection(connection)
-    expected = SevenBridgesConfig(**ops_args)
+    expected = config
     assert actual == expected
 
 
@@ -64,14 +64,15 @@ def test_that_an_empty_connection_can_be_mapped():
 @pytest.mark.integration
 def test_that_a_valid_client_can_be_constructed_and_tested():
     # Authenticate using the environment variable
-    factory = SevenBridgesClientFactory()
+    config = SevenBridgesConfig()
+    factory = SevenBridgesClientFactory(config)
     client = factory.get_client(test=True)
     assert isinstance(client, Api)
 
 
 @pytest.mark.integration
-def test_for_an_error_when_constructing_and_testing_an_invalid_client(client_args):
+def test_for_an_error_when_constructing_and_testing_an_invalid_client(config):
     # Authenticate using the environment variable
-    factory = SevenBridgesClientFactory(client_args["api_endpoint"], "foo")
+    factory = SevenBridgesClientFactory(config)
     with pytest.raises(ClientRequestError):
         factory.get_client(test=True)

--- a/tests/services/sevenbridges/test_hook.py
+++ b/tests/services/sevenbridges/test_hook.py
@@ -2,7 +2,7 @@ import pytest
 from airflow.models.connection import Connection
 from sevenbridges import Api
 
-from orca.errors import ClientAttrError
+from orca.errors import ConfigError
 from orca.services.sevenbridges import SevenBridgesHook, SevenBridgesOps
 
 
@@ -29,5 +29,5 @@ class TestWithoutAirflow:
     ):
         empty_connection = Connection(uri="sbg://")
         mocker.patch.object(hook, "connection", empty_connection)
-        with pytest.raises(ClientAttrError):
-            hook.ops
+        with pytest.raises(ConfigError):
+            hook.ops.client

--- a/tests/services/sevenbridges/test_ops.py
+++ b/tests/services/sevenbridges/test_ops.py
@@ -1,21 +1,21 @@
 import pytest
 
-from orca.errors import UnexpectedMatchError
+from orca.errors import ConfigError, UnexpectedMatchError
 from orca.services.sevenbridges import SevenBridgesOps
 
 
 @pytest.mark.usefixtures("patch_os_environ")
 class TestWithEmptyEnv:
-    def test_that_constructions_from_creds_works(self, ops_config, mock_api_init):
-        SevenBridgesOps.from_config(ops_config)
+    def test_that_constructions_from_creds_works(self, config, mock_api_init):
+        SevenBridgesOps(config).client
         mock_api_init.assert_called_once()
 
     def test_for_error_when_constructing_from_config_without_project(
-        self, ops_config, mock_api_init
+        self, config, mock_api_init
     ):
-        ops_config.project = None
-        with pytest.raises(ValueError):
-            SevenBridgesOps.from_config(ops_config)
+        config.project = None
+        with pytest.raises(ConfigError):
+            SevenBridgesOps(config).project
 
     def test_that_the_client_is_used_to_get_a_task(self, mock_task, mock_ops):
         mock_ops.client.tasks.query.return_value = [mock_task]


### PR DESCRIPTION
When I tried implementing the Nextflow Tower service, I noticed that several ways to improve the existing base classes, mostly by moving all config-related functionality into `BaseConfig`. This improves the code's adherence to the single-responsibility principle (SRP). This also paves the way to adding support for configuration files to `BaseConfig` without having to change anything about the other base classes. That's a sign that SRP is being followed. 

Unfortunately, I started refactoring on top of #10, so I can't easily merge these changes into #8, where `BaseConfig` is first introduced. I'll leave a comment on #8 about this PR. 