### PR TITLE
[ORCA-155] Implement basic Nextflow Tower service

### DIFF
--- a/src/orca/services/nextflowtower/__init__.py
+++ b/src/orca/services/nextflowtower/__init__.py
@@ -1,0 +1,13 @@
+"""Submodule for NextflowTower platforms (like Tower.nf)."""
+
+from orca.services.nextflowtower.client_factory import NextflowTowerClientFactory
+from orca.services.nextflowtower.config import NextflowTowerConfig
+from orca.services.nextflowtower.hook import NextflowTowerHook
+from orca.services.nextflowtower.ops import NextflowTowerOps
+
+__all__ = [
+    "NextflowTowerConfig",
+    "NextflowTowerClientFactory",
+    "NextflowTowerOps",
+    "NextflowTowerHook",
+]

--- a/src/orca/services/nextflowtower/client.py
+++ b/src/orca/services/nextflowtower/client.py
@@ -1,0 +1,128 @@
+from typing import Any
+
+import requests
+from pydantic.dataclasses import dataclass
+
+
+@dataclass(kw_only=False)
+class NextflowTowerClient:
+    """Simple Python client for making requests to Nextflow Tower.
+
+    Attributes:
+        api_endpoint: API endpoint for a Nextflow Tower platform.
+        auth_token: An authentication token for the platform specified
+            by the ``api_endpoints`` value.
+    """
+
+    auth_token: str
+    api_endpoint: str
+
+    def update_kwarg(
+        self, kwargs: dict[str, Any], key1: str, key2: str, default: Any
+    ) -> None:
+        """Ensure a default value for a nested key in kwargs.
+
+        Args:
+            kwargs: Keyword arguments
+            key1: Top-level key.
+            key2: Nested key.
+            default: Default value.
+        """
+        kwargs.setdefault(key1, dict())
+        if not isinstance(kwargs[key1], dict):
+            message = f"The '{key1}' keyword argument must be a dictionary."
+            raise ValueError(message)
+        kwargs[key1].setdefault(key2, default)
+        if not isinstance(kwargs[key1][key2], type(default)):
+            message = (
+                f"The value for kwargs['{key1}']['{key2}'] ({kwargs[key1][key2]}) "
+                f"is not the expected type ({type(default)})."
+            )
+            raise ValueError(message)
+
+    def request(self, method: str, path: str, **kwargs) -> requests.Response:
+        """Make an authenticated HTTP request.
+
+        Args:
+            method: An HTTP method (GET, PUT, POST, or DELETE).
+            path: The API path with the parameters filled in.
+            **kwargs: Additional named arguments passed through to
+                requests.request().
+
+        Returns:
+            The raw Response object to allow for special handling
+        """
+        valid_methods = {"GET", "PUT", "POST", "DELETE"}
+        if method not in valid_methods:
+            message = f"Method ({method}) not among valid options ({valid_methods})."
+            raise ValueError(message)
+
+        url = f"{self.api_endpoint}/{path}"
+
+        auth_header = f"Bearer {self.auth_token}"
+        self.update_kwarg(kwargs, "headers", "Authorization", auth_header)
+
+        return requests.request(method, url, **kwargs)
+
+    def request_json(self, method: str, path: str, **kwargs) -> dict[str, Any]:
+        """Make an authenticated HTTP request and parse the JSON response.
+
+        See ``TowerClient.request`` for argument definitions.
+
+        Raises:
+            HTTPError: If something went wrong with the request.
+
+        Returns:
+            A dictionary from deserializing the JSON response.
+        """
+        response = self.request(method, path, **kwargs)
+        response.raise_for_status()
+        return response.json()
+
+    def request_paged(self, method: str, path: str, **kwargs) -> list[dict[str, Any]]:
+        """Iterate through pages of results for a given request.
+
+        See ``TowerClient.request`` for argument definitions.
+
+        Raises:
+            ValueError: If the 'params' keyword argument
+                isn't a dictionary
+
+        Returns:
+            The cumulative list of items from all pages.
+        """
+        self.update_kwarg(kwargs, "params", "max", 50)
+        self.update_kwarg(kwargs, "params", "offset", 0)
+
+        num_items = 0
+        total_size = 1  # Artificial value for initiating the while-loop
+
+        all_items = list()
+        while num_items < total_size:
+            kwargs["params"]["offset"] = num_items
+            json = self.request_json(method, path, **kwargs)
+
+            if "totalSize" not in json:
+                message = f"'totalSize' not in response JSON ({json}) as expected."
+                raise requests.exceptions.HTTPError(message)
+            total_size = json.pop("totalSize")
+
+            if len(json) != 1:
+                message = f"Expected one other key aside from 'totalSize' ({json})."
+                raise requests.exceptions.HTTPError(message)
+            _, items = json.popitem()
+
+            num_items += len(items)
+            all_items.extend(items)
+
+        return all_items
+
+    # TODO: Consider creating a `client` submodule folder to organize methods
+    def get_user_info(self) -> dict[str, Any]:
+        """Describe current user.
+
+        Returns:
+            Current user
+        """
+        path = "/user-info"
+        return self.request_json("get", path)

--- a/src/orca/services/nextflowtower/client_factory.py
+++ b/src/orca/services/nextflowtower/client_factory.py
@@ -1,0 +1,62 @@
+from pydantic.dataclasses import dataclass
+
+from orca.errors import ConfigError
+from orca.services.base.client_factory import BaseClientFactory
+from orca.services.nextflowtower.client import NextflowTowerClient
+from orca.services.nextflowtower.config import NextflowTowerConfig
+
+
+@dataclass(kw_only=False)
+class NextflowTowerClientFactory(BaseClientFactory):
+    """Factory for constructing Nextflow Tower clients.
+
+    Attributes:
+        config: Configuration object for this service.
+
+    Class Variables:
+        client_class: The client class for this service.
+    """
+
+    config: NextflowTowerConfig
+
+    client_class = NextflowTowerClient
+
+    def create_client(self) -> NextflowTowerClient:
+        """Create an authenticated client.
+
+        Typically, this involves pulling values from the configuration,
+        ensuring that non-optional arguments are not set to None, and
+        using them to instantiate a client class.
+
+        Raises:
+            ConfigError: If the configuration is invalid.
+
+        Returns:
+            An authenticated client object.
+        """
+        kwargs = dict()
+        api_endpoint = self.config.api_endpoint
+        auth_token = self.config.auth_token
+
+        if api_endpoint is None or auth_token is None:
+            message = f"Config ({self.config}) is missing api_endpoint or auth_token."
+            raise ConfigError(message)
+
+        kwargs["api_endpoint"] = api_endpoint.rstrip("/")
+        kwargs["auth_token"] = auth_token
+
+        return NextflowTowerClient(**kwargs)
+
+    @classmethod
+    def test_client_request(cls, client: NextflowTowerClient) -> None:
+        """Make a test request with an authenticated request.
+
+        This method does not need to perform any error handling.
+        That is taken care of by the ``test_client()`` method.
+        That said, this method can raise an error if a response
+        is made but indicates a problem.
+
+        Args:
+            client: An authenticated client for this service.
+        """
+        client.get_user_info()

--- a/src/orca/services/nextflowtower/config.py
+++ b/src/orca/services/nextflowtower/config.py
@@ -1,0 +1,53 @@
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic.dataclasses import dataclass
+
+from orca.services.base.config import BaseConfig
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
+
+
+@dataclass(kw_only=False)
+class NextflowTowerConfig(BaseConfig):
+    """Simple container class for service-related configuration.
+
+    Attributes:
+        api_endpoint: API endpoint for a Nextflow Tower platform.
+        auth_token: An authentication token for the platform specified
+            by the ``api_endpoints`` value.
+        workspace: A Nextflow Tower workspace ID.
+
+    Class Variables:
+        connection_env_var: The name of the environment variable whose
+            value is an Airflow connection URI for this service.
+    """
+
+    api_endpoint: Optional[str] = None
+    auth_token: Optional[str] = None
+    workspace: Optional[int] = None
+
+    connection_env_var = "NEXTFLOWTOWER_CONNECTION_URI"
+
+    @classmethod
+    def parse_connection(cls, connection: Connection) -> dict[str, Any]:
+        """Parse Airflow connection as arguments for this configuration.
+
+        Args:
+            connection: An Airflow connection object.
+
+        Returns:
+            Keyword arguments for this configuration.
+        """
+        api_endpoint = None
+        if connection.host:
+            schema = connection.schema or ""
+            api_endpoint = f"https://{connection.host}/{schema}"
+            api_endpoint = api_endpoint.rstrip("/")
+
+        kwargs = {
+            "api_endpoint": api_endpoint,
+            "auth_token": connection.password,
+            "workspace": connection.extra_dejson.get("workspace"),
+        }
+        return kwargs

--- a/src/orca/services/nextflowtower/hook.py
+++ b/src/orca/services/nextflowtower/hook.py
@@ -1,0 +1,24 @@
+from orca.services.base.hook import BaseOrcaHook
+from orca.services.nextflowtower.config import NextflowTowerConfig
+from orca.services.nextflowtower.ops import NextflowTowerOps
+
+
+class NextflowTowerHook(BaseOrcaHook):
+    """Wrapper around Nextflow Tower client and ops classes.
+
+    Class Variables:
+        conn_name_attr: Inherited Airflow attribute (e.g., "sbg_conn_id").
+        default_conn_name: Inherited Airflow attribute (e.g., "sbg_default").
+        conn_type: Inherited Airflow attribute (e.g., "sbg").
+        hook_name: Inherited Airflow attribute (e.g., "SevenBridges").
+        ops_class: The Ops class for this service.
+        config_class: The configuration class for this service.
+    """
+
+    conn_name_attr = "tower_conn_id"
+    default_conn_name = "tower_default"
+    conn_type = "tower"
+    hook_name = "NextflowTower"
+
+    ops_class = NextflowTowerOps
+    config_class = NextflowTowerConfig

--- a/src/orca/services/nextflowtower/ops.py
+++ b/src/orca/services/nextflowtower/ops.py
@@ -1,0 +1,32 @@
+from functools import cached_property
+
+from pydantic.dataclasses import dataclass
+
+from orca.errors import ConfigError
+from orca.services.base.ops import BaseOps
+from orca.services.nextflowtower.client_factory import NextflowTowerClientFactory
+from orca.services.nextflowtower.config import NextflowTowerConfig
+
+
+@dataclass(kw_only=False)
+class NextflowTowerOps(BaseOps):
+    """Collection of operations for Nextflow Tower.
+
+    Attributes:
+        config: A configuration object for this service.
+
+    Class Variables:
+        client_factory_class: The class for constructing clients.
+    """
+
+    config: NextflowTowerConfig
+
+    client_factory_class = NextflowTowerClientFactory
+
+    @cached_property
+    def workspace(self) -> int:
+        """The currently active Nextflow Tower workspace."""
+        if self.config.workspace is None:
+            message = f"Config ({self.config}) does not specify a workspace."
+            raise ConfigError(message)
+        return self.config.workspace

--- a/tests/services/nextflowtower/conftest.py
+++ b/tests/services/nextflowtower/conftest.py
@@ -1,0 +1,58 @@
+import pytest
+from airflow.exceptions import AirflowNotFoundException
+from airflow.models.connection import Connection
+
+from orca.services.base.hook import BaseHook
+from orca.services.nextflowtower import (
+    NextflowTowerConfig,
+    NextflowTowerHook,
+    NextflowTowerOps,
+)
+
+
+@pytest.fixture
+def mock_client(mocker):
+    mocker.patch("orca.services.nextflowtower.client_factory.NextflowTowerClient")
+
+
+@pytest.fixture
+def config():
+    config = NextflowTowerConfig(
+        api_endpoint="https://api.tower.nf/",
+        auth_token="foo",
+        workspace=123456789,
+    )
+    yield config
+
+
+@pytest.fixture
+def mock_ops(config, mock_client):
+    yield NextflowTowerOps(config)
+
+
+@pytest.fixture
+def connection_uri(config):
+    bare_url = config.api_endpoint.replace("https://", "")
+    host, schema = bare_url.rstrip("/").rsplit("/", maxsplit=1)
+    token = config.auth_token
+    project = config.project
+    yield f"sbg://:{token}@{host}/{schema}/?project={project}"
+
+
+@pytest.fixture
+def connection(connection_uri):
+    yield Connection(uri=connection_uri)
+
+
+@pytest.fixture
+def patch_get_connection(mocker, connection):
+    connection_mock = mocker.patch.object(BaseHook, "get_connection")
+    connection_mock.side_effect = AirflowNotFoundException
+    yield connection_mock
+
+
+@pytest.fixture
+def hook(patch_get_connection):
+    # The conn_id param doesn't matter because the `patch_get_connection`
+    # fixture will ensure that the same Connection object is returned
+    yield NextflowTowerHook("foo")

--- a/tests/services/nextflowtower/responses.py
+++ b/tests/services/nextflowtower/responses.py
@@ -1,0 +1,38 @@
+"""Example responses for different Tower endpoints.
+
+To generate these, you can visit the OpenAPI page linked below and
+make example requests after setting your authentication token at the
+top of the page. You'll have to replace JSON literals ('null', 'false',
+'true') with Python equivalents ('None', 'False', 'True'). Take care
+of redacting any values that shouldn't be public.
+
+https://tower-dev.sagebionetworks.org/api/openapi
+"""
+
+get_user_info = {
+    "user": {
+        "id": 2,
+        "userName": "bgrande",
+        "email": "bruno.grande@sagebase.org",
+        "firstName": None,
+        "lastName": None,
+        "organization": "@Sage-Bionetworks",
+        "description": None,
+        "avatar": "REDACTED",
+        "trusted": True,
+        "notification": True,
+        "termsOfUseConsent": None,
+        "marketingConsent": None,
+        "options": {
+            "githubToken": "REDACTED",
+            "maxRuns": None,
+            "hubspotId": None,
+        },
+        "lastAccess": "2023-02-24T20:11:50Z",
+        "dateCreated": "2021-08-31T20:44:08Z",
+        "lastUpdated": "2023-02-24T20:11:50Z",
+        "deleted": False,
+    },
+    "needConsent": False,
+    "defaultWorkspaceId": None,
+}

--- a/tests/services/sevenbridges/conftest.py
+++ b/tests/services/sevenbridges/conftest.py
@@ -30,8 +30,11 @@ from sevenbridges.api import (
 )
 
 from orca.services.base.hook import BaseHook
-from orca.services.sevenbridges import SevenBridgesHook, SevenBridgesOps
-from orca.services.sevenbridges.client_factory import SevenBridgesConfig
+from orca.services.sevenbridges import (
+    SevenBridgesConfig,
+    SevenBridgesHook,
+    SevenBridgesOps,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
I wanted to use the new base classes to implement a new service, so I chose Nextflow Tower. This implementation is very basic, but it serves to demonstrate the utility of the base classes. 

I realized that I can probably parametrize the tests as well for different services to avoid duplication. I'll look into that next. 

- [ ] Implement tests for Nextflow Tower