### PR TITLE
[ORCA-217] Improve usability of Nextflow Tower service

### DIFF
--- a/src/orca/__init__.py
+++ b/src/orca/__init__.py
@@ -25,5 +25,4 @@ handler.setFormatter(formatter)
 # Configure a module logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.handlers.clear()
 logger.addHandler(handler)

--- a/src/orca/__init__.py
+++ b/src/orca/__init__.py
@@ -14,7 +14,19 @@ finally:
 
 import logging
 
-
-# Set default logging handler to avoid "No handler found" warnings
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+# Capture warnings made with the warnings standard module
 logging.captureWarnings(True)
+
+# Configure a stream handler
+handler = logging.StreamHandler()
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+handler.setFormatter(formatter)
+
+# Configure a module logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.handlers.clear()
+logger.addHandler(handler)
+
+# Silence Airflow logging
+logging.getLogger("airflow").setLevel(logging.ERROR)

--- a/src/orca/__init__.py
+++ b/src/orca/__init__.py
@@ -27,6 +27,3 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logger.handlers.clear()
 logger.addHandler(handler)
-
-# Silence Airflow logging
-logging.getLogger("airflow").setLevel(logging.ERROR)

--- a/src/orca/services/base/ops.py
+++ b/src/orca/services/base/ops.py
@@ -20,6 +20,8 @@ class BaseOps(Generic[ConfigClass, ClientClass]):
         3) Provide values to all class variables (defined below).
         4) Provide implementations for all abstract methods.
         5) Update the type hints for attributes and class variables.
+        6) Update the config attribute to have a default factory set to
+           the config class using the `dataclasses.field()` function.
 
     Attributes:
         config: A configuration object for this service.

--- a/src/orca/services/nextflowtower/models.py
+++ b/src/orca/services/nextflowtower/models.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 from orca.services.nextflowtower.utils import dedup, get_nested
 
 
-class WorkflowStatus(Enum):
+class WorkflowStatus(str, Enum):
     """Valid values for the status of a Tower workflow.
 
     Attributes:
@@ -317,4 +317,4 @@ class Workflow(BaseTowerModel):
     @property
     def is_done(self) -> bool:
         """Whether the workflow is done running."""
-        return self.status.value in WorkflowStatus.terminal_states.value
+        return self.status in WorkflowStatus.terminal_states

--- a/src/orca/services/sevenbridges/ops.py
+++ b/src/orca/services/sevenbridges/ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import field
 from functools import cached_property
 from typing import Any, Optional, cast
 
@@ -23,7 +24,7 @@ class SevenBridgesOps(BaseOps):
         client_factory_class: The class for constructing clients.
     """
 
-    config: SevenBridgesConfig
+    config: SevenBridgesConfig = field(default_factory=SevenBridgesConfig)
 
     client_factory_class = SevenBridgesClientFactory
 

--- a/tests/services/base/test_ops.py
+++ b/tests/services/base/test_ops.py
@@ -1,9 +1,23 @@
+from dataclasses import fields
+from typing import get_type_hints
+
 from orca.services.base import BaseClientFactory, BaseConfig
 
 
 def test_that_config_is_set(ops):
     assert hasattr(ops, "config")
     assert isinstance(ops.config, BaseConfig)
+
+
+def test_that_config_has_a_default_factory(ops):
+    config_field = [f for f in fields(ops) if f.name == "config"][0]
+    assert getattr(config_field, "default_factory", None) is not None
+
+
+def test_that_config_has_a_matching_default_factory(ops):
+    config_field = [f for f in fields(ops) if f.name == "config"][0]
+    config_type = get_type_hints(ops.__class__)["config"]
+    assert config_field.default_factory == config_type
 
 
 def test_that_client_factory_class_is_set(service):


### PR DESCRIPTION
As I was writing the [demonstration script](https://gist.github.com/BrunoGrandePhD/a12dddcedda331905e13f57bc83e1447), I found a few tweaks to improve the usability of `py-orca`: 

- Add some logging to be more transparent about what happens when you launch a workflow
- Construct configuration objects by default in `Ops` classes to conveniently pull from environment
- Document and test that all `Ops` class add a default factory for their `config` attributes
- Improve (slightly) the handling of the `WorkflowStatus` enum by inheriting from `str`
  - Starting in Python 3.11, you can use `StrEnum` for this, but it's too new to use in `py-orca`
- Fix bug with incrementing the suffix on the wrong run name
- Add a `get_workflow()` operation for the convenience of not having to provide the workspace ID

Here's an example run of the demo script: 

```console
$ pipenv run python3 demo.py
Loading .env environment variables...
Found an ongoing previous run: demo_8 (4F41pYrbgfXXGg)
Starting to monitor workflow: demo_8 (4F41pYrbgfXXGg)
Not done yet. Status is 'RUNNING'. Checking again in 5 min...
Not done yet. Status is 'RUNNING'. Checking again in 5 min...
Not done yet. Status is 'RUNNING'. Checking again in 5 min...
Not done yet. Status is 'RUNNING'. Checking again in 5 min...
Not done yet. Status is 'RUNNING'. Checking again in 5 min...
Done! Final status is 'SUCCEEDED'.
```