### PR TITLE
[ORCA-209] Monitor Submission View

### DIFF
--- a/src/orca/services/synapse/ops.py
+++ b/src/orca/services/synapse/ops.py
@@ -38,6 +38,8 @@ class SynapseOps(BaseOps):
         Returns:
             True if there are "RECEIVED" submissions, False otherwise.
         """
-        received_submissions = syn.getSubmissionBundles(evaluation_id, status="RECEIVED")
+        received_submissions = self.client.getSubmissionBundles(
+            evaluation_id, status="RECEIVED"
+        )
         submissions_num = sum(1 for submission in received_submissions)
         return submissions_num > 0

--- a/src/orca/services/synapse/ops.py
+++ b/src/orca/services/synapse/ops.py
@@ -31,7 +31,7 @@ class SynapseOps(BaseOps):
     client_factory_class = SynapseClientFactory
 
     client: ClassVar[Synapse]
-      
+
     @cached_property
     def fs(self) -> SynapseFS:
         """Synapse file system."""
@@ -43,7 +43,6 @@ class SynapseOps(BaseOps):
 
         return SynapseFS(auth_token=auth_token)
 
-   
     def monitor_evaluation_queue(self, evaluation_id: str) -> bool:
         """Monitor an evaluation queue in Synapse.
 
@@ -58,4 +57,3 @@ class SynapseOps(BaseOps):
         )
         submissions_num = sum(1 for submission in received_submissions)
         return submissions_num > 0
-

--- a/src/orca/services/synapse/ops.py
+++ b/src/orca/services/synapse/ops.py
@@ -29,17 +29,15 @@ class SynapseOps(BaseOps):
 
     client: ClassVar[Synapse]
 
-    def monitor_submission_view(self, view_id: str) -> bool:
-        """Monitor a submission view for completion.
+    def monitor_evaluation_queue(self, evaluation_id: str) -> bool:
+        """Monitor an evaluation queue in Synapse.
 
         Args:
-            view_id: The ID of the view to monitor.
+            evaluation_id: The Synapse ID of the queue to monitor.
 
         Returns:
-            True if there are new "RECEIVED" submissions, False otherwise.
+            True if there are "RECEIVED" submissions, False otherwise.
         """
-        received_submissions = self.client.tableQuery(
-            f"select * from {view_id} where status = 'RECEIVED'"
-        )
-        recevied_rows = received_submissions.asRowSet()
-        return len(recevied_rows["rows"]) > 0
+        received_submissions = syn.getSubmissionBundles(evaluation_id, status="RECEIVED")
+        submissions_num = sum(1 for submission in received_submissions)
+        return submissions_num > 0

--- a/src/orca/services/synapse/ops.py
+++ b/src/orca/services/synapse/ops.py
@@ -28,3 +28,18 @@ class SynapseOps(BaseOps):
     client_factory_class = SynapseClientFactory
 
     client: ClassVar[Synapse]
+
+    def monitor_submission_view(self, view_id: str) -> bool:
+        """Monitor a submission view for completion.
+
+        Args:
+            view_id: The ID of the view to monitor.
+
+        Returns:
+            True if there are new "RECEIVED" submissions, False otherwise.
+        """
+        received_submissions = self.client.tableQuery(
+            f"select * from {view_id} where status = 'RECEIVED'"
+        )
+        recevied_rows = received_submissions.asRowSet()
+        return len(recevied_rows["rows"]) > 0

--- a/tests/services/synapse/conftest.py
+++ b/tests/services/synapse/conftest.py
@@ -1,6 +1,30 @@
 import pytest
 
+from orca.services.synapse import SynapseClientFactory, SynapseConfig, SynapseOps
+
 
 @pytest.fixture
 def syn_project_id():
     yield "syn51469029"
+
+
+@pytest.fixture
+def config(patch_os_environ):
+    yield SynapseConfig("foo")
+
+
+@pytest.fixture
+def client(config):
+    factory = SynapseClientFactory(config=config)
+    yield factory.create_client()
+
+
+@pytest.fixture
+def mocked_ops(config, client, mocker):
+    mocker.patch.object(SynapseOps, "client", return_value=client)
+    yield SynapseOps(config)
+
+
+@pytest.fixture
+def ops(config):
+    yield SynapseOps(config)

--- a/tests/services/synapse/test_ops.py
+++ b/tests/services/synapse/test_ops.py
@@ -1,0 +1,22 @@
+def test_monitor_evaluation_queue_returns_false_when_there_are_no_new_submissions(
+    mocker, mocked_ops
+):
+    mock = mocker.patch.object(
+        mocked_ops.client, "getSubmissionBundles", return_value=[]
+    )
+    result = mocked_ops.monitor_evaluation_queue("foo")
+    mock.assert_called_once_with("foo", status="RECEIVED")
+    assert result is False
+
+
+def test_monitor_evaluation_queue_returns_true_when_there_are_new_submissions(
+    mocker, mocked_ops
+):
+    mock = mocker.patch.object(
+        mocked_ops.client,
+        "getSubmissionBundles",
+        return_value=["submission_1", "submission_2"],
+    )
+    result = mocked_ops.monitor_evaluation_queue("foo")
+    mock.assert_called_once_with("foo", status="RECEIVED")
+    assert result

--- a/tests/services/synapse/test_ops.py
+++ b/tests/services/synapse/test_ops.py
@@ -11,7 +11,7 @@ def test_for_an_error_when_accessing_fs_without_credentials(
     with pytest.raises(ConfigError):
         ops.fs.listdir(syn_project_id)
 
-        
+
 def test_monitor_evaluation_queue_returns_false_when_there_are_no_new_submissions(
     mocker, mocked_ops
 ):
@@ -34,4 +34,3 @@ def test_monitor_evaluation_queue_returns_true_when_there_are_new_submissions(
     result = mocked_ops.monitor_evaluation_queue("foo")
     mock.assert_called_once_with("foo", status="RECEIVED")
     assert result
-


### PR DESCRIPTION
This PR adds the method `monitor_submission_view` to `SynapseOps`.

The function simply queries a submission view id to retrieve rows where the submission `status` is `RECEIVED`, reads the rows, and returns `TRUE` if the number of rows is greater than 0 or `FALSE` if not.

This will be used in the initial step of a submission evaluation DAG, where the DAG will only execute fully if this step returns `TRUE`.