### PR TITLE
Improve `.env.example` template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,8 @@
 # the access token are required. Do not omit them.
 #
 # Examples:
-#   SYNAPSE_CONNECTION_URI=syn://:<access-token>@
-#   SYNAPSE_CONNECTION_URI=syn://:eyJ0[...]QP7g@
+#   export SYNAPSE_CONNECTION_URI=syn://:<access-token>@
+#   export SYNAPSE_CONNECTION_URI=syn://:eyJ0[...]QP7g@
 
 
 # SevenBridges credentials
@@ -48,9 +48,9 @@
 # the access token are required. Do not omit them.
 #
 # Examples:
-#   SEVENBRIDGES_CONNECTION_URI=sbg://:<access-token>@<api-base-endpoint>[/?project=<project-id>]
-#   SEVENBRIDGES_CONNECTION_URI=sbg://:f560[...]bf9d@cavatica-api.sbgenomics.com/v2
-#   SEVENBRIDGES_CONNECTION_URI=sbg://:f560[...]bf9d@cavatica-api.sbgenomics.com/v2/?project=bgrande/sandbox
+#   export SEVENBRIDGES_CONNECTION_URI=sbg://:<access-token>@<api-base-endpoint>[/?project=<project-id>]
+#   export SEVENBRIDGES_CONNECTION_URI=sbg://:f560[...]bf9d@cavatica-api.sbgenomics.com/v2
+#   export SEVENBRIDGES_CONNECTION_URI=sbg://:f560[...]bf9d@cavatica-api.sbgenomics.com/v2/?project=bgrande/sandbox
 
 
 # Nextflow Tower credentials
@@ -69,6 +69,6 @@
 # the access token are required. Do not omit them.
 #
 # Examples:
-#   NEXTFLOWTOWER_CONNECTION_URI=tower://:<access-token>@<api-base-endpoint>[/?workspace=<organization-name>/<workspace-name>]
-#   NEXTFLOWTOWER_CONNECTION_URI=tower://:eyJ0[...]MA==@api.tower.nf
-#   NEXTFLOWTOWER_CONNECTION_URI=tower://:eyJ0[...]MA==@api.tower.nf/?workspace=sage-bionetworks/example-project
+#   export NEXTFLOWTOWER_CONNECTION_URI=tower://:<access-token>@<api-base-endpoint>[/?workspace=<organization-name>/<workspace-name>]
+#   export NEXTFLOWTOWER_CONNECTION_URI=tower://:eyJ0[...]MA==@api.tower.nf
+#   export NEXTFLOWTOWER_CONNECTION_URI=tower://:eyJ0[...]MA==@tower.sagebionetworks.org/api/?workspace=sage-bionetworks/example-project


### PR DESCRIPTION
We have to `source` the `.env` file and include `export` 