### PR TITLE
[ORCA-280] Adds Support for Nextflow Entrypoints in `LaunchInfo`

### DIFF
--- a/src/orca/services/nextflowtower/models.py
+++ b/src/orca/services/nextflowtower/models.py
@@ -167,6 +167,7 @@ class LaunchInfo(BaseTowerModel):
     label_ids: list[int] = field(default_factory=list)
     resume: bool = False
     session_id: Optional[str] = None
+    entry_name: Optional[str] = ""
 
     @root_validator()
     def check_resume_and_session_id(cls, values: dict[str, Any]):
@@ -223,7 +224,7 @@ class LaunchInfo(BaseTowerModel):
             "configProfiles": dedup(self.profiles),
             "configText": self.nextflow_config,
             "dateCreated": None,
-            "entryName": None,
+            "entryName": self.get("entry_name"),
             "headJobCpus": None,
             "headJobMemoryMb": None,
             "id": None,


### PR DESCRIPTION
This PR adds support for Nextflow entrypoints to be passed via `LaunchInfo` when `launch_workflow` is run. This is done simply by adding the `entry_name` variable to the `LaunchInfo` class. `entry_name` is optional when `LaunchInfo` is instantiated and defaults to `""` rather than `None` to avoid needing to hard-code an update during the `launch_workflow` call. This change has been tested using variations on the following script (and with environment variables configured similar to those needed to run the `demo.py` script in this repo):
```
from orca.services.nextflowtower import NextflowTowerOps
from orca.services.nextflowtower.models import LaunchInfo
import os

ops = NextflowTowerOps()

info = LaunchInfo(
    run_name="model_to_data_orca_test_entry_set",
    pipeline="Sage-Bionetworks-Workflows/nf-synapse-challenge",
    profiles=["tower"],
    revision="main",
    entry_name="MODEL_TO_DATA_CHALLENGE",
    workspace_secrets=["SYNAPSE_AUTH_TOKEN"],
)

ops.launch_workflow(info, "ondemand")
```
Nextflow Tower test runs:
- [Workflow that supports entrypoints with `entry_name` set](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-project/watch/3eXqRdwfBdRAeu)
- [Workflow that supports entrypoints with `entry_name` not set](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-project/watch/qdgPiCFGP7HGQ)
__Note:__ When `entry_name` is not set and there is no default workflow in `main.nf`, the run will finish "successfully", but nothing actually happened. We may want to include something that catches when `entry_name` is not set in `nf-synapse-challenge`.
- [Workflow that does not support entrypoints with `entry_name` not set](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-project/watch/1ljP4jfJ8YQ1D0)