### PR TITLE
[ORCA-282] Adds "Keep Alive" CI Step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
         # Prevent scheduled workflow from ever being paused
       - name: Keepalive Workflow
         uses: gautamkrishnar/keepalive-workflow@1.1.0
-        
-                    
+
+
   test:
     needs: prepare
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
           name: python-distribution-files
           path: dist/
           retention-days: 1
-
+        # Prevent scheduled workflow from ever being paused
+      - name: Keepalive Workflow
+        uses: gautamkrishnar/keepalive-workflow@1.1.0
+                    
   test:
     needs: prepare
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
         # Prevent scheduled workflow from ever being paused
       - name: Keepalive Workflow
         uses: gautamkrishnar/keepalive-workflow@1.1.0
+        with:
+          time_elapsed: 44
 
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,9 @@ jobs:
           path: dist/
           retention-days: 1
         # Prevent scheduled workflow from ever being paused
+      - name: Keepalive Workflow
         uses: gautamkrishnar/keepalive-workflow@1.1.0
-
+        
                     
   test:
     needs: prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
           path: dist/
           retention-days: 1
         # Prevent scheduled workflow from ever being paused
-      - name: Keepalive Workflow
         uses: gautamkrishnar/keepalive-workflow@1.1.0
+
                     
   test:
     needs: prepare


### PR DESCRIPTION
This PR introduces a CI step to prevent our scheduled workflow job from being paused due to the repository not being updated for >=60days. This step uses the [Keep Alive Action](https://github.com/marketplace/actions/keepalive-workflow). This Action will run each time our scheduled job does, and if it detects that this repo has not been updated for >=44 days it will push a dummy commit thus preventing our job from being paused after the 60-day limit is hit.