### PR TITLE
[IBCDPE-848] Query for `id` only

### DIFF
--- a/src/orca/services/synapse/ops.py
+++ b/src/orca/services/synapse/ops.py
@@ -97,7 +97,7 @@ class SynapseOps(BaseOps):
             f"select id from {submission_view} where status = '{submission_status}'"
         )
 
-        submission_ids = query_results.asDataFrame().tolist()
+        submission_ids = query_results.asDataFrame()["id"].tolist()
 
         return submission_ids
 

--- a/src/orca/services/synapse/ops.py
+++ b/src/orca/services/synapse/ops.py
@@ -94,10 +94,10 @@ class SynapseOps(BaseOps):
 
         # Get all submissions for the given ``submission_view``
         query_results = self.client.tableQuery(
-            f"select * from {submission_view} where status = '{submission_status}'"
+            f"select id from {submission_view} where status = '{submission_status}'"
         )
 
-        submission_ids = query_results.asDataFrame()["id"].tolist()
+        submission_ids = query_results.asDataFrame().tolist()
 
         return submission_ids
 

--- a/tests/services/synapse/test_ops.py
+++ b/tests/services/synapse/test_ops.py
@@ -134,7 +134,7 @@ def test_get_submissions_with_status(
 
             # Assertions
             syn_mock.tableQuery.assert_called_once_with(
-                f"select * from {submission_view} where status = '{submission_status}'"
+                f"select id from {submission_view} where status = '{submission_status}'"
             )
             table_mock.asDataFrame.assert_called()
             assert result == input_dict["id"]


### PR DESCRIPTION
### problem
It's unnecessary to query for all the columns in a Synapse table view if the only column of interest is the Submission ID.

### solution
Select only the `id` column in the `tableQuery` call, and have the mock `tableQuery` call reflect this in the tests.

### testing & preview
Unit tests still passing with these changes, so behavior is as expected.