### PR TITLE
Adds `gh_token` to KeepAlive workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ on:
     # Avoid using all the resources/limits available by checking only
     # relevant branches and tags. Other branches can be checked via PRs.
     branches: [main]
-    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
-  pull_request:  # Run in every PR
-  workflow_dispatch:  # Allow manually triggering the workflow
+    tags: ["v[0-9]*", "[0-9]+.[0-9]+*"] # Match tags that resemble a version
+  pull_request: # Run in every PR
+  workflow_dispatch: # Allow manually triggering the workflow
   schedule:
     # Run roughly every 15 days at 00:00 UTC
     # (useful to check if updates on dependencies break the package)
-    - cron: '0 0 1,16 * *'
+    - cron: "0 0 1,16 * *"
 
 concurrency:
   group: >-
@@ -31,9 +31,9 @@ jobs:
       tarball-path: ${{ steps.distribution-paths.outputs.tarball }}
     steps:
       - uses: actions/checkout@v3
-        with: {fetch-depth: 0}  # deep clone for setuptools-scm
+        with: { fetch-depth: 0 } # deep clone for setuptools-scm
       - uses: actions/setup-python@v4
-        with: {python-version: "3.11"}
+        with: { python-version: "3.11" }
       - name: Run static analysis and format checkers
         run: pipx run pre-commit run --all-files --show-diff-on-failure
       - name: Install tox-gh plugin
@@ -59,18 +59,18 @@ jobs:
         uses: gautamkrishnar/keepalive-workflow@1.1.0
         with:
           time_elapsed: 44
-
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     needs: prepare
     strategy:
       matrix:
         python:
-        - "3.10"  # oldest Python supported
-        - "3.11"  # newest Python that is stable
+          - "3.10" # oldest Python supported
+          - "3.11" # newest Python that is stable
         platform:
-        - ubuntu-latest
-        - macos-latest
+          - ubuntu-latest
+          - macos-latest
     env:
       OS: ${{ matrix.platform }}
       PYTHON: ${{ matrix.python }}
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - uses: actions/download-artifact@v3
-        with: {name: python-distribution-files, path: dist/}
+        with: { name: python-distribution-files, path: dist/ }
       - name: Install tox-gh plugin
         run: python -m pip install tox-gh>=1.2
       - name: Setup test suite
@@ -93,8 +93,8 @@ jobs:
           NEXTFLOWTOWER_CONNECTION_URI: ${{ secrets.NEXTFLOWTOWER_CONNECTION_URI }}
           SYNAPSE_CONNECTION_URI: ${{ secrets.SYNAPSE_CONNECTION_URI }}
         run: >-
-            tox --installpkg '${{ needs.prepare.outputs.wheel-path }}'
-            -- -rFEx --durations 10 --color yes
+          tox --installpkg '${{ needs.prepare.outputs.wheel-path }}'
+          -- -rFEx --durations 10 --color yes
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -113,9 +113,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with: {python-version: "3.11"}
+        with: { python-version: "3.11" }
       - uses: actions/download-artifact@v3
-        with: {name: python-distribution-files, path: dist/}
+        with: { name: python-distribution-files, path: dist/ }
       - name: Publish Python Package to PyPI
         env:
           TWINE_REPOSITORY: pypi
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
-        with: {name: python-distribution-files, path: dist/}
+        with: { name: python-distribution-files, path: dist/ }
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2


### PR DESCRIPTION
Recently we had a [problem](https://github.com/Sage-Bionetworks/fs-synapse/pull/4) with `fs-synapse` where the `keepalive-workflow` did not have proper permissions to run when CI runs to prevent the workflow from being paused. This has not become an issue in this repo yet, but I want to prevent any future problems.