### PR TITLE
[IBCDPE-1111] Upgrade airflow version

### DIFF
--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -1,2 +1,2 @@
--c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt
-apache-airflow==2.7.2
+-c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.10.txt
+apache-airflow==2.9.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ python_requires = >=3.10, <3.12
 # Updates here should be reflected in `docs/requirements.txt`
 # Also, run `tox -e pipenv` to update your virtual environment
 install_requires =
-    apache-airflow==2.7.2
+    apache-airflow==2.9.3
     pydantic~=1.10
     sqlalchemy<2.0  # To address SQLAlchemy warning (https://sqlalche.me/e/b8d9)
     typing-extensions~=4.5


### PR DESCRIPTION
**Problem:**

1. In order to upgrade our apache airflow instance the version of airflow needs to be updated here.

**Solution:**

1. Upgrading the airflow dependency

**Testing:**

1. I tested this by creating a new apache airflow image and deploying it the test kubernetes cluster to verify DAGs were still able to run



Related PRs:

1. https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/71
2. https://github.com/Sage-Bionetworks-Workflows/eks-stack/pull/42