### PR TITLE
[DPE-1253] Adds PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# **Problem:**
+
+- Describe the specific technical problem that this PR solves.
+- Include  details such as:
+    - How you reproduced the problem
+    - What code is affected
+    - Any relevant background information
+
+# **Solution:**
+
+- Describe the specific technical solution that this PR provides.
+- Include details such as:
+    - How you debugged the problem
+    - Why you chose this solution
+    - Does the solution make any impact beyond the immediate problem
+    - Any necessary technical debt incurred
+    - Any important design decisions/links to design documentation (if applicable)
+
+# **Testing:**
+
+- Describe any testing that was performed to validate the solution.
+- Include details such as:
+    - How you tested the solution
+    - Any relevant test results (Do not include any test results that may contain sensitive information)
+    - Any automated tests that were added to the codebase


### PR DESCRIPTION
# **Problem:**

This repository did not have a PR template.

# **Solution:**

I added a PR template.

# **Testing:**

There isn't a way to test, but the same template worked for `py-orca` in this [PR](https://github.com/Sage-Bionetworks-Workflows/py-dcqc/pull/58).
