### PR TITLE
[DPE-1275] Upgrade to the newest fs-synapse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           SYNAPSE_CONNECTION_URI: ${{ secrets.SYNAPSE_CONNECTION_URI }}
         run: >-
           tox --installpkg '${{ needs.prepare.outputs.wheel-path }}'
-          -- -rFEx --durations 10 --color yes
+          -- -rFEx --durations 10 --color yes -n 4
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ exclude =
 all =
     challengeutils~=4.3
     synapseclient~=4.7
-    fs-synapse~=2.0
+    fs-synapse~=2.1
     sevenbridges-python~=2.9
     requests~=2.28
     urllib3<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ testing =
     pytest-mock~=3.0
     pytest-dotenv~=0.5.2
     pytest-asyncio~=0.21.0
+    pytest-xdist>=2.2,<3.0.0
 
 # Dependencies for development (used by Pipenv)
 dev =


### PR DESCRIPTION
# **Problem:**

- There are some issues we are seeing with the apache airflow scheduler not running at expected times or consistently. fs-synapse is a transitive dependency that also needs to be upgrades.

# **Solution:**

- Upgrade to the latest fs-synapse

# **Testing:**

- Once a new image is created we will be deploying the new images out to the dev k8s cluster
