### PR TITLE
[DPE-1275] Skip checks on creation of Syn client

### DIFF
--- a/src/orca/services/synapse/client_factory.py
+++ b/src/orca/services/synapse/client_factory.py
@@ -35,7 +35,7 @@ class SynapseClientFactory(BaseClientFactory):
         Returns:
             An authenticated client object.
         """
-        client = Synapse(silent=True)
+        client = Synapse(silent=True, skip_checks=True)
         auth_token = self.config.auth_token
 
         if auth_token is None:


### PR DESCRIPTION
# **Problem:**

- When the Synapse client class instance is created around 3 HTTP calls are fired off to Synapse. The issue as shown in https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1188 is that no timeout is attached to the requests, meaning it can hang forever in the airflow DAG:
![image](https://github.com/user-attachments/assets/c333b520-20f4-4b08-aa19-846680ef0fc7)


# **Solution:**

- Skip the checks on creation of the SYN Client - This is a temporary workaround until the above linked PR is released

# **Testing:**

- Will be testing locally and when the service is deployed eventually to k8s
