### PR TITLE
[DPE-1288] Updates synapseclient version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     outputs:
       wheel-path: ${{ steps.distribution-paths.outputs.wheel }}
       tarball-path: ${{ steps.distribution-paths.outputs.tarball }}
@@ -54,12 +56,9 @@ jobs:
           name: python-distribution-files
           path: dist/
           retention-days: 1
-        # Prevent scheduled workflow from ever being paused
       - name: Keepalive Workflow
-        uses: gautamkrishnar/keepalive-workflow@2.0.10
-        with:
-          time_elapsed: 44
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: liskin/gh-workflow-keepalive@v1
+        if: github.event_name == 'schedule'
 
   test:
     needs: prepare

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ exclude =
 # Additional dependencies for specific services
 all =
     challengeutils~=4.3
-    synapseclient~=4.7
+    synapseclient~=4.8
     fs-synapse~=2.1
     sevenbridges-python~=2.9
     requests~=2.28


### PR DESCRIPTION
# **Problem:**

We need access to new OOP models such as `DatasetCollection` in `orca-recipes` DAGs.

# **Solution:**

Upgrade the `synapseclient` version in this repository.

# **Testing:**

Ci pipeline.

# **Notes:**

The old `gautamkrishnar/keepalive-workflow@2.0.10` workflow we used to use to prevent GH from shutting off our automated actions appears to have been [banned](https://github.com/gautamkrishnar/keepalive-workflow) from the platform due to some policy violation. I have replaced it with a different one that serves the same purpose, but will run each time our scheduled testing runs rather than every X number of days.