### PR TITLE
[DPE-1474] remove entry_name, add new profiles

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -46,8 +46,7 @@ class RnaseqDataset:
             run_name=run_name,
             pipeline="Sage-Bionetworks-Workflows/nf-synapse",
             revision="main",
-            profiles=["docker"],
-            entry_name="NF_SYNSTAGE",
+            profiles=["docker", "synstage"],
             params={
                 "input": samplesheet_uri,
             },
@@ -97,8 +96,7 @@ class RnaseqDataset:
             run_name=self.get_run_name("synindex"),
             pipeline="Sage-Bionetworks-Workflows/nf-synapse",
             revision="main",
-            profiles=["docker"],
-            entry_name="NF_SYNINDEX",
+            profiles=["docker", "synindex"],
             params={
                 "s3_prefix": rnaseq_outdir_uri,
                 "parent_id": self.output_folder,


### PR DESCRIPTION
# **Problem:**

The current `demo.py` is outdated, following changes to the `entry` parameter, causing workflow runs to fail:

https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/5FkvJwV3YCQMnf

# **Solution:**

Similar to [other references to Tower](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/blob/69d1fe6bcda0eeeec0b7d6ac77991b5e5c96a855/dags/challenge_dag_factory.py#L285), remove `entry_param` from the LaunchInfo calls, and add the [profiles](https://github.com/Sage-Bionetworks-Workflows/nf-synapse/blob/77293186c4ee3e74de98cc698bb17db125bc332e/nextflow.config#L15) that contain the new `params.entry` parameter introduced last year that replaces the `Workflow entry name` field in SP.

# **Testing:**

