### PR TITLE
[DPE-1657] Address `launch_synstage` error in `demo.py`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,3 +302,17 @@ on [PyPI], the following steps can be used to release a new version for
 [virtualenv]: https://virtualenv.pypa.io/en/stable/
 [repository]: https://github.com/sage-bionetworks-workflows/py-orca
 [issue tracker]: https://github.com/sage-bionetworks-workflows/py-orca/issues
+
+---
+
+## Troubleshooting CI
+
+> This is a living document. As new CI failures are diagnosed and resolved, add them here so future contributors don't have to rediscover the same issues.
+
+### Integration tests fail with `401 Unauthorized` or unexpected API errors
+
+**Symptom:** Integration tests (e.g., `test_that_a_workflow_can_be_launched`) fail in CI with authentication or API errors, even though the tests pass locally.
+
+**Cause:** The `NEXTFLOWTOWER_CONNECTION_URI` GitHub Actions secret MAY contain an expired or outdated API token.
+
+**Fix:** Regenerate a valid Nextflow Tower API token following the format outlined in `.env.example` and update the secret in the repository's GitHub Actions settings (`Settings > Secrets and variables > Actions > NEXTFLOWTOWER_CONNECTION_URI`).

--- a/src/orca/services/nextflowtower/client.py
+++ b/src/orca/services/nextflowtower/client.py
@@ -1,5 +1,7 @@
 from typing import Any, Optional
 
+import warnings
+
 import requests
 from pydantic.dataclasses import dataclass
 from requests.exceptions import HTTPError
@@ -91,16 +93,24 @@ class NextflowTowerClient:
         return response.json()
 
     def request_paged(self, method: str, path: str, **kwargs) -> dict[str, Any]:
-        """Iterate through pages of results for a given request.
+        """Paginate through all pages of a paged API endpoint and collect results.
+
+        Sends repeated requests, incrementing the offset each time, until all
+        items have been retrieved. Expects each response to contain a size key
+        (``totalSize`` or ``total``) and exactly one list-valued key holding
+        the items for that page. Warns if multiple list-valued keys are found
+        and uses the first. Raises if no list-valued key is found.
 
         See ``TowerClient.request`` for argument definitions.
 
         Raises:
-            HTTPError: If the response doesn't match the expectation
-                for a paged endpoint.
+            HTTPError: If the response contains no list-valued key, or if the
+                total number of collected items does not match the declared
+                total size.
 
         Returns:
-            The cumulative list of items from all pages.
+            A dict with ``totalSize`` (or ``total``) and the items key mapped to the full
+            combined list across all pages.
         """
         # Ensure defaults for pagination query parameters
         self.update_kwarg(kwargs, "params", "max", 50)
@@ -114,7 +124,18 @@ class NextflowTowerClient:
             kwargs["params"]["offset"] = num_items
             json = self.request_json(method, path, **kwargs)
             total_size = json.pop("totalSize", None) or json.pop("total", 0)
-            key_name, items = json.popitem()
+            list_keys = [(k, v) for k, v in json.items() if isinstance(v, list)]
+            if not list_keys:
+                raise HTTPError(
+                    f"Paged response contained no list-valued key. "
+                    f"Received keys/types: { {k: type(v).__name__ for k, v in json.items()} }"
+                )
+            if len(list_keys) > 1:
+                warnings.warn(
+                    f"Paged response contained multiple list-valued keys: "
+                    f"{[k for k, _ in list_keys]}. Using the first: '{list_keys[0][0]}'."
+                )
+            key_name, items = list_keys[0]
             num_items += len(items)
             all_items.extend(items)
 

--- a/src/orca/services/nextflowtower/client.py
+++ b/src/orca/services/nextflowtower/client.py
@@ -1,6 +1,5 @@
-from typing import Any, Optional
-
 import warnings
+from typing import Any, Optional
 
 import requests
 from pydantic.dataclasses import dataclass
@@ -109,8 +108,8 @@ class NextflowTowerClient:
                 total size.
 
         Returns:
-            A dict with ``totalSize`` (or ``total``) and the items key mapped to the full
-            combined list across all pages.
+            A dict with ``totalSize`` (or ``total``) and the items key mapped
+            to the full combined list across all pages.
         """
         # Ensure defaults for pagination query parameters
         self.update_kwarg(kwargs, "params", "max", 50)
@@ -126,14 +125,17 @@ class NextflowTowerClient:
             total_size = json.pop("totalSize", None) or json.pop("total", 0)
             list_keys = [(k, v) for k, v in json.items() if isinstance(v, list)]
             if not list_keys:
+                received = {k: type(v).__name__ for k, v in json.items()}
                 raise HTTPError(
                     f"Paged response contained no list-valued key. "
-                    f"Received keys/types: { {k: type(v).__name__ for k, v in json.items()} }"
+                    f"Received keys/types: {received}"
                 )
             if len(list_keys) > 1:
                 warnings.warn(
                     f"Paged response contained multiple list-valued keys: "
-                    f"{[k for k, _ in list_keys]}. Using the first: '{list_keys[0][0]}'."
+                    f"{[k for k, _ in list_keys]}. "
+                    f"Using the first: '{list_keys[0][0]}'.",
+                    stacklevel=2,
                 )
             key_name, items = list_keys[0]
             num_items += len(items)

--- a/tests/services/nextflowtower/test_client.py
+++ b/tests/services/nextflowtower/test_client.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from requests.exceptions import HTTPError
 
@@ -166,3 +168,36 @@ def test_that_get_task_logs_works(client, mocker, get_response):
     )
     mock.assert_called()
     assert result == "Ciao world!"
+
+
+def test_that_request_paged_raises_when_no_list_key(client, mocker):
+    mock = mocker.patch.object(client, "request_json")
+    mock.return_value = {"totalSize": 1, "hasMore": True}
+    with pytest.raises(HTTPError, match="no list-valued key"):
+        client.list_labels(98765)
+
+
+def test_that_request_paged_warns_when_multiple_list_keys(client, mocker):
+    mock = mocker.patch.object(client, "request_json")
+    mock.return_value = {
+        "totalSize": 1,
+        "labels": [{"id": 1, "name": "foo", "value": None, "resource": False}],
+        "extras": [{"id": 2}],
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        client.list_labels(98765)
+    assert len(caught) == 1
+    assert "multiple list-valued keys" in str(caught[0].message)
+
+
+def test_that_request_paged_tolerates_extra_boolean_fields(client, mocker):
+    """Regression test: API adding boolean fields alongside the list should not crash."""
+    mock = mocker.patch.object(client, "request_json")
+    mock.return_value = {
+        "totalSize": 1,
+        "labels": [{"id": 1, "name": "foo", "value": None, "resource": False}],
+        "hasMoreEntries": True,
+    }
+    result = client.list_labels(98765)
+    assert len(result) == 1

--- a/tests/services/nextflowtower/test_client.py
+++ b/tests/services/nextflowtower/test_client.py
@@ -192,7 +192,6 @@ def test_that_request_paged_warns_when_multiple_list_keys(client, mocker):
 
 
 def test_that_request_paged_tolerates_extra_boolean_fields(client, mocker):
-    """Regression test: API adding boolean fields alongside the list should not crash."""
     mock = mocker.patch.object(client, "request_json")
     mock.return_value = {
         "totalSize": 1,

--- a/tests/services/nextflowtower/test_integration.py
+++ b/tests/services/nextflowtower/test_integration.py
@@ -24,20 +24,17 @@ def ops(config):
 
 
 @pytest.mark.integration
-@pytest.mark.xdist_group("tower")
 def test_that_the_config_can_pull_information_from_env(config):
     assert config.auth_token
     assert config.api_endpoint
 
 
 @pytest.mark.integration
-@pytest.mark.xdist_group("tower")
 def test_that_a_valid_client_can_be_constructed_and_tested(client):
     assert client.list_user_workspaces()
 
 
 @pytest.mark.integration
-@pytest.mark.xdist_group("tower")
 def test_that_a_workflow_can_be_launched(ops):
     launch_info = models.LaunchInfo(
         pipeline="nextflow-io/hello",
@@ -48,7 +45,6 @@ def test_that_a_workflow_can_be_launched(ops):
 
 
 @pytest.mark.integration
-@pytest.mark.xdist_group("tower")
 def test_that_a_workflow_can_be_retrieved(ops):
     launch_info = models.LaunchInfo(
         pipeline="nextflow-io/hello",
@@ -60,7 +56,6 @@ def test_that_a_workflow_can_be_retrieved(ops):
 
 
 @pytest.mark.integration
-@pytest.mark.xdist_group("tower")
 def test_that_a_workflow_can_be_relaunched(ops):
     launch_info = models.LaunchInfo(
         pipeline="nextflow-io/hello",

--- a/tests/services/nextflowtower/test_integration.py
+++ b/tests/services/nextflowtower/test_integration.py
@@ -24,17 +24,20 @@ def ops(config):
 
 
 @pytest.mark.integration
+@pytest.mark.xdist_group("tower")
 def test_that_the_config_can_pull_information_from_env(config):
     assert config.auth_token
     assert config.api_endpoint
 
 
 @pytest.mark.integration
+@pytest.mark.xdist_group("tower")
 def test_that_a_valid_client_can_be_constructed_and_tested(client):
     assert client.list_user_workspaces()
 
 
 @pytest.mark.integration
+@pytest.mark.xdist_group("tower")
 def test_that_a_workflow_can_be_launched(ops):
     launch_info = models.LaunchInfo(
         pipeline="nextflow-io/hello",
@@ -45,6 +48,7 @@ def test_that_a_workflow_can_be_launched(ops):
 
 
 @pytest.mark.integration
+@pytest.mark.xdist_group("tower")
 def test_that_a_workflow_can_be_retrieved(ops):
     launch_info = models.LaunchInfo(
         pipeline="nextflow-io/hello",
@@ -56,6 +60,7 @@ def test_that_a_workflow_can_be_retrieved(ops):
 
 
 @pytest.mark.integration
+@pytest.mark.xdist_group("tower")
 def test_that_a_workflow_can_be_relaunched(ops):
     launch_info = models.LaunchInfo(
         pipeline="nextflow-io/hello",


### PR DESCRIPTION
# **Problem:**

The Nextflow Tower API has drifted from the way we handle the client response bodies in `NextflowTowerClient`. More specifically, when the `list_workflows` function is launched (from `NextflowTowerClient`) as part of the DAG's `launch_synstage` step, it calls upon the `request_paged` function that is wrapped by `get`, which is where we iterate through paginated results for a given endpoint (in this case `/workflow`) under the assumption that the response JSON returns only 1 other key containing a list-type value after the `totalSize` or `total` key is popped out.

This is no longer the case. As you can see in the OpenAPI docs for Seqera below, the `/workflow` API now contains an extra key (`hasMore`) that holds a boolean-type value:

https://cloud.seqera.io/openapi/index.html#get-/workflow

# **Solution:**

Since `request_paged(...)` serves multiple API endpoints beyond just `/workflow`, we still need to extract the key items implicitly from the response. To make API drift more visible when it happens, loud and fast-failing error handling is added so issues surface immediately and the Nextflow logs on the Seqera platform point directly to the relevant source code.

Specifically:

- [x] Error raised when the paged response returns no list-valued key
- [x] Warning raised when the paged response returns more than 1 list-valued key 
- [x] New unit tests for the client.py

Out of scope:
- [x] New troubleshooting CI section in contributing.md 

# **Testing:**

Trace log before:

```
(py-orca-venv-3.10) (synapseclient) bash-3.2$ python demo.py run --dataset_id 'syn51514585' --s3_prefix 's3://example-dev-project-tower-scratch/work'
[2026-05-12T10:55:05.609-0400] {crypto.py:82} WARNING - empty cryptography key - values will not be stored encrypted.
Metaflow 2.18.11 executing TowerRnaseqFlow for user:jmedina
Validating your flow...
    The graph looks good!
[ ... ]
[ JUNK ]
[ ... ]
2026-05-12 10:55:16.033 [1778597705774448/transfer_samplesheet_to_s3/4 (pid 49446)] Task finished successfully.
2026-05-12 10:55:16.043 [1778597705774448/launch_synstage/5 (pid 49475)] Task is starting.
2026-05-12 10:55:17.276 [1778597705774448/launch_synstage/5 (pid 49475)] [2026-05-12T10:55:17.274-0400] {crypto.py:82} WARNING - empty cryptography key - values will not be stored encrypted.
2026-05-12 10:55:18.193 [1778597705774448/launch_synstage/5 (pid 49475)] <flow TowerRnaseqFlow step launch_synstage> failed:
2026-05-12 10:55:18.210 [1778597705774448/launch_synstage/5 (pid 49475)] Internal error
2026-05-12 10:55:18.212 [1778597705774448/launch_synstage/5 (pid 49475)] Traceback (most recent call last):
2026-05-12 10:55:18.212 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/py-orca-venv-3.10/lib/python3.10/site-packages/metaflow/cli.py", line 658, in main
2026-05-12 10:55:18.212 [1778597705774448/launch_synstage/5 (pid 49475)] start(auto_envvar_prefix="METAFLOW", obj=state)
[ ... ]
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] self.synstage_id = self.tower.launch_workflow(launch_info, "spot")
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/src/orca/services/nextflowtower/ops.py", line 141, in launch_workflow
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] latest_run = self.get_latest_previous_workflow(launch_info)
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/src/orca/services/nextflowtower/ops.py", line 243, in get_latest_previous_workflow
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] previous_runs = self.list_previous_workflows(launch_info)
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/src/orca/services/nextflowtower/ops.py", line 215, in list_previous_workflows
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] workflows = self.list_workflows()
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/src/orca/services/nextflowtower/ops.py", line 203, in list_workflows
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] workflows = self.client.list_workflows(search_filter, self.workspace_id)
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/src/orca/services/nextflowtower/client.py", line 369, in list_workflows
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] json = self.get(path=path, params=params)
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/src/orca/services/nextflowtower/client.py", line 138, in get
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] json = self.request_paged("GET", path, kwargs)
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] File "/Users/jmedina/Documents/forks/py-orca/src/orca/services/nextflowtower/client.py", line 118, in request_paged
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] num_items += len(items)
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] TypeError: object of type 'bool' has no len()
2026-05-12 10:55:18.414 [1778597705774448/launch_synstage/5 (pid 49475)] 
2026-05-12 10:55:18.415 [1778597705774448/launch_synstage/5 (pid 49475)] Task failed.
2026-05-12 10:55:18.415 Workflow failed.
2026-05-12 10:55:18.415 Terminating 0 active tasks...
2026-05-12 10:55:18.415 Flushing logs...
    Step failure:
    Step launch_synstage (task-id 5) failed.
```

Trace log after:

```
2026-05-12 11:59:19.361 [1778601548277750/launch_synstage/5 (pid 67733)] Task is starting.
2026-05-12 11:59:20.674 [1778601548277750/launch_synstage/5 (pid 67733)] [2026-05-12T11:59:20.673-0400] {crypto.py:82} WARNING - empty cryptography key - values will not be stored encrypted.
2026-05-12 11:59:24.421 [1778601548277750/launch_synstage/5 (pid 67733)] 2026-05-12 11:59:24,420 - INFO - Launched a new workflow run: my_test_dataset_synstage_0fbdc040-23cc-410d-81c5-129dbd37ef63 (5cT8UsBYMrRVEf)
2026-05-12 11:59:24.422 [1778601548277750/launch_synstage/5 (pid 67733)] [2026-05-12T11:59:24.420-0400] {ops.py:175} INFO - Launched a new workflow run: my_test_dataset_synstage_0fbdc040-23cc-410d-81c5-129dbd37ef63 (5cT8UsBYMrRVEf)
2026-05-12 11:59:24.678 [1778601548277750/launch_synstage/5 (pid 67733)] Task finished successfully.
2026-05-12 11:59:24.688 [1778601548277750/monitor_synstage/6 (pid 67764)] Task is starting.
1548277750/monitor_synstage/6 (pid 67764)] 2026-05-12 12:03:27,332 - INFO - Workflow(run_name=my_test_dataset_synstage_0fbdc040-23cc-410d-81c5-129dbd37ef63, id=5cT8UsBYMrRVEf, state=SUBMITTED) is not done yet...
[ ... ]
[ JUNK ]
[ ... ]
2026-05-12 12:14:29.380 No tasks are waiting in the queue.
2026-05-12 12:14:29.380 end step has not started
2026-05-12 12:14:29.380 [1778601548277750/monitor_synstage/6 (pid 67764)] [2026-05-12T12:14:29.378-0400] {ops.py:278} INFO - Workflow(run_name=my_test_dataset_synstage_0fbdc040-23cc-410d-81c5-129dbd37ef63, id=5cT8UsBYMrRVEf, state=SUCCEEDED) is now done!
2026-05-12 12:14:29.734 [1778601548277750/monitor_synstage/6 (pid 67764)] Task finished successfully.
2026-05-12 12:14:29.753 [1778601548277750/end/7 (pid 72338)] Task is starting.
2026-05-12 12:14:31.569 [1778601548277750/end/7 (pid 72338)] [2026-05-12T12:14:31.567-0400] {crypto.py:82} WARNING - empty cryptography key - values will not be stored encrypted.
2026-05-12 12:14:31.720 [1778601548277750/end/7 (pid 72338)] Completed processing RnaseqDataset(id='my_test_dataset', samplesheet='syn51514475', output_folder='syn51514559')
2026-05-12 12:14:31.721 [1778601548277750/end/7 (pid 72338)] synstage workflow ID: 5cT8UsBYMrRVEf
2026-05-12 12:14:31.909 [1778601548277750/end/7 (pid 72338)] Task finished successfully.
2026-05-12 12:14:31.911 Done!
```

[Nextflow run](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/5cT8UsBYMrRVEf)